### PR TITLE
Manage Puppet scripts within GeoWave project and package as an RPM

### DIFF
--- a/packaging/puppet/geowave/manifests/accumulo.pp
+++ b/packaging/puppet/geowave/manifests/accumulo.pp
@@ -1,0 +1,15 @@
+class geowave::accumulo {
+
+  package { "geowave-${geowave::hadoop_vendor_version}-accumulo":
+    ensure => latest,
+    tag    => 'geowave-package',
+  }
+
+  if !defined(Package["geowave-${geowave::hadoop_vendor_version}-core"]) {
+    package { "geowave-${geowave::hadoop_vendor_version}-core":
+      ensure => latest,
+      tag    => 'geowave-package',
+    }
+  }
+
+}

--- a/packaging/puppet/geowave/manifests/app.pp
+++ b/packaging/puppet/geowave/manifests/app.pp
@@ -1,0 +1,20 @@
+class geowave::app {
+
+  $geowave_base_app_rpms = [
+    "geowave-${geowave::hadoop_vendor_version}-docs",
+    "geowave-${geowave::hadoop_vendor_version}-ingest",
+  ]
+
+  package { $geowave_base_app_rpms:
+    ensure => latest,
+    tag    => 'geowave-package',
+  }
+
+  if !defined(Package["geowave-${geowave::hadoop_vendor_version}-core"]) {
+    package { "geowave-${geowave::hadoop_vendor_version}-core":
+      ensure => latest,
+      tag    => 'geowave-package',
+    }
+  }
+
+}

--- a/packaging/puppet/geowave/manifests/init.pp
+++ b/packaging/puppet/geowave/manifests/init.pp
@@ -1,0 +1,24 @@
+class geowave(
+  $hadoop_vendor_version  = $geowave::params::hadoop_vendor_version,
+  $install_accumulo       = $geowave::params::install_accumulo,
+  $install_app            = $geowave::params::install_app,
+  $install_app_server     = $geowave::params::install_app_server,
+  $http_port              = $geowave::params::http_port
+) inherits geowave::params {
+
+  if $install_accumulo {
+    class {'geowave::accumulo':}
+  }
+
+  if $install_app {
+    class {'geowave::app':}
+  }
+
+  if $install_app_server {
+    anchor {'geowave::begin': } ->
+      class {'geowave::server':} ->
+      class {'geowave::service':} ->
+    anchor {'geowave::end':}
+  }
+
+}

--- a/packaging/puppet/geowave/manifests/params.pp
+++ b/packaging/puppet/geowave/manifests/params.pp
@@ -1,0 +1,7 @@
+class geowave::params {
+  $hadoop_vendor_version = undef
+  $install_accumulo = false
+  $install_app = false
+  $install_app_server = false
+  $http_port = '8080'
+}

--- a/packaging/puppet/geowave/manifests/repo.pp
+++ b/packaging/puppet/geowave/manifests/repo.pp
@@ -1,0 +1,22 @@
+class geowave::repo(
+  $repo_name       = 'geowave',
+  $repo_desc       = 'GeoWave Repo',
+  $repo_enabled    = 1,
+  $repo_base_url   = 'http://s3.amazonaws.com/geowave-rpms/release/noarch/',
+  $repo_refresh_md = 21600, # Repo metadata is good for 6 hours by default 
+  $repo_priority   = 15,
+  $repo_gpg_check  = 0,
+) {
+
+  yumrepo {$repo_name:
+    baseurl         => $repo_base_url,
+    descr           => $repo_desc,
+    enabled         => $repo_enabled,
+    gpgcheck        => $repo_gpg_check,
+    priority        => $repo_priority,
+    metadata_expire => $repo_refresh_md,
+  }
+
+  Yumrepo[$repo_name] -> Package<|tag == 'geowave-package' |>
+
+}

--- a/packaging/puppet/geowave/manifests/server.pp
+++ b/packaging/puppet/geowave/manifests/server.pp
@@ -1,0 +1,28 @@
+class geowave::server {
+
+  $http_port = $geowave::http_port
+
+  package { "geowave-${geowave::hadoop_vendor_version}-jetty":
+    ensure => latest,
+    tag    => 'geowave-package',
+    notify => Service['geowave']
+  }
+
+  if !defined(Package["geowave-${geowave::hadoop_vendor_version}-core"]) {
+    package { "geowave-${geowave::hadoop_vendor_version}-core":
+      ensure => latest,
+      tag    => 'geowave-package',
+    }
+  }
+
+  file {'/usr/local/geowave/geoserver/etc/jetty.xml':
+    ensure  => file,
+    content => template('geowave/jetty.xml.erb'),
+    owner   => 'geowave',
+    group   => 'geowave',
+    mode    => '644',
+    require => Package["geowave-${geowave::hadoop_vendor_version}-jetty"],
+    notify  => Service['geowave']
+  }
+
+}

--- a/packaging/puppet/geowave/manifests/service.pp
+++ b/packaging/puppet/geowave/manifests/service.pp
@@ -1,0 +1,10 @@
+class geowave::service {
+
+  service { 'geowave':
+    ensure     => 'running',
+    enable     => true,
+    hasstatus  => true,
+    hasrestart => true,
+  }
+
+}

--- a/packaging/puppet/geowave/templates/jetty.xml.erb
+++ b/packaging/puppet/geowave/templates/jetty.xml.erb
@@ -1,0 +1,174 @@
+<?xml version="1.0"?>
+<!DOCTYPE Configure PUBLIC "-//Mort Bay Consulting//DTD Configure//EN" "http://jetty.mortbay.org/configure.dtd">
+
+<!-- =============================================================== -->
+<!-- Configure the Jetty Server                                      -->
+<!-- =============================================================== -->
+<Configure id="Server" class="org.mortbay.jetty.Server">
+
+    <!-- =========================================================== -->
+    <!-- Server Thread Pool                                          -->
+    <!-- =========================================================== -->
+    <Set name="ThreadPool">
+      <New class="org.mortbay.thread.BoundedThreadPool">
+        <Set name="minThreads">10</Set>
+        <Set name="lowThreads">50</Set>
+        <Set name="maxThreads">250</Set>
+      </New>
+    </Set>
+
+    <!-- =========================================================== -->
+    <!-- Set connectors                                              -->
+    <!-- =========================================================== -->
+    <!-- One of each type!                                           -->
+    <!-- =========================================================== -->
+
+    <!-- Use this connector for many frequently idle connections
+         and for threadless continuations.
+    -->    
+    <Call name="addConnector">
+      <Arg>
+          <New class="org.mortbay.jetty.nio.SelectChannelConnector">
+            <Set name="port"><SystemProperty name="jetty.port" default="<%= @http_port %>"/></Set>
+            <Set name="maxIdleTime">30000</Set>
+            <Set name="Acceptors">2</Set>
+            <Set name="confidentialPort">8443</Set>
+          </New>
+      </Arg>
+    </Call>
+        
+
+    <!-- Use this connector if NIO is not available.
+    <Call name="addConnector">
+      <Arg>
+          <New class="org.mortbay.jetty.bio.SocketConnector">
+            <Set name="port">8081</Set>
+            <Set name="maxIdleTime">50000</Set>
+            <Set name="lowResourceMaxIdleTime">1500</Set>
+          </New>
+      </Arg>
+    </Call>
+    -->
+
+    <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+    <!-- To add a HTTPS SSL listener                                     -->
+    <!-- see jetty-ssl.xml to add an ssl connector. use                  -->
+    <!-- java -jar start.jar etc/jetty.xml etc/jetty-ssl.xml             -->
+    <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+    
+
+
+    <!-- =========================================================== -->
+    <!-- Set handler Collection Structure                            --> 
+    <!-- =========================================================== -->
+    <Set name="handler">
+      <New id="handlers" class="org.mortbay.jetty.handler.HandlerCollection">
+        <Set name="handlers">
+         <Array type="org.mortbay.jetty.Handler">
+           <Item>
+             <New id="contexts" class="org.mortbay.jetty.handler.ContextHandlerCollection"/>
+           </Item>
+           <Item>
+             <New id="defaultHandler" class="org.mortbay.jetty.handler.DefaultHandler"/>
+           </Item>
+           <Item>
+             <New id="requestLog" class="org.mortbay.jetty.handler.RequestLogHandler"/>
+           </Item>
+         </Array>
+        </Set>
+      </New>
+    </Set>
+    
+    
+    <!-- ======================================================= -->
+    <!-- Configure a WebApp                                      -->
+    <!-- ======================================================= -->
+    <!--
+    <New id="TestContext" class="org.mortbay.jetty.webapp.WebAppContext">
+      <Arg><Ref id="contexts"/></Arg>
+      <Arg><SystemProperty name="jetty.home" default="."/>/webapps/test</Arg>
+      <Arg>/</Arg>
+      <Set name="classLoader">
+        <New class="org.mortbay.jetty.webapp.TransformingWebAppClassLoader">
+          <Arg><Ref id="TestContext"/></Arg>
+        </New>
+      </Set>
+      <Set name="defaultsDescriptor"><SystemProperty name="jetty.home" default="."/>/etc/webdefault.xml</Set>
+      <Set name="virtualHosts">
+        <Array type="java.lang.String">
+          <Item>localhost</Item>
+        </Array>
+      </Set>
+      
+      <Get name="SessionHandler">
+        <Set name="SessionManager">
+          <New class="org.mortbay.jetty.servlet.HashSessionManager">
+            <Set name="maxInactiveInterval">600</Set>
+          </New>
+        </Set>
+      </Get>
+    </New>
+    -->
+
+    <!-- ======================================================= -->
+    <!-- Configure a Context                                     -->
+    <!-- ======================================================= -->
+    <New class="org.mortbay.jetty.servlet.Context">
+      <Arg><Ref id="contexts"/></Arg>
+      <Arg>/javadoc</Arg>
+      <Set name="resourceBase"><SystemProperty name="jetty.home" default="."/>/javadoc/</Set>
+      <Call name="addServlet">
+        <Arg>org.mortbay.jetty.servlet.DefaultServlet</Arg>
+        <Arg>/</Arg>
+      </Call>
+    </New>
+
+    <!-- =========================================================== -->
+    <!-- Discover contexts from webapps directory                    -->
+    <!-- =========================================================== -->
+    <Call class="org.mortbay.jetty.webapp.WebAppContext" name="addWebApplications">
+      <Arg><Ref id="contexts"/></Arg>
+      <Arg><SystemProperty name="jetty.home" default="."/>/webapps</Arg>
+      <Arg><SystemProperty name="jetty.home" default="."/>/etc/webdefault.xml</Arg>
+      <Arg type="boolean">True</Arg>  <!-- extract -->
+      <Arg type="boolean">True</Arg> <!-- parent priority class loading -->
+    </Call>
+
+    <!-- =========================================================== -->
+    <!-- Configure Realms                                            -->
+    <!-- =========================================================== -->
+    <Set name="UserRealms">
+      <Array type="org.mortbay.jetty.security.UserRealm">
+        <Item>
+          <New class="org.mortbay.jetty.security.HashUserRealm">
+            <Set name="name">Test Realm</Set>
+            <Set name="config"><SystemProperty name="jetty.home" default="."/>/etc/realm.properties</Set>
+          </New>
+        </Item>
+      </Array>
+    </Set>
+    
+
+    <!-- =========================================================== -->
+    <!-- Configure Request Log                                       -->
+    <!-- =========================================================== -->
+    <Ref id="requestLog">
+      <Set name="requestLog">
+        <New id="requestLogImpl" class="org.mortbay.jetty.NCSARequestLog">
+          <Arg><SystemProperty name="jetty.logs" default="./logs"/>/request.log</Arg>
+          <Set name="retainDays">90</Set>
+          <Set name="append">true</Set>
+          <Set name="extended">false</Set>
+          <Set name="LogTimeZone">GMT</Set>
+        </New>
+      </Set>
+    </Ref>
+
+    <!-- =========================================================== -->
+    <!-- extra options                                               -->
+    <!-- =========================================================== -->
+    <Set name="stopAtShutdown">true</Set>
+    <!-- ensure/prevent Server: header being sent to browsers        -->
+    <Set name="sendServerVersion">true</Set>
+
+</Configure>

--- a/packaging/rpm/admin-scripts/jenkins-build-geowave.sh
+++ b/packaging/rpm/admin-scripts/jenkins-build-geowave.sh
@@ -21,3 +21,7 @@ mv $WORKSPACE/geowave-types/target/*-ingest-tool.jar $WORKSPACE/geowave-types/ta
 git fetch --all
 git archive origin/gh-pages --remote=$WORKSPACE --format=zip > $WORKSPACE/geowave-deploy/target/gh-pages.zip
 
+# Copy over the puppet scripts
+pushd $WORKSPACE/packaging/puppet
+tar cvzf $WORKSPACE/geowave-deploy/target/puppet-scripts.tar.gz $WORKSPACE/packaging/puppet/geowave
+popd

--- a/packaging/rpm/centos/6/.gitignore
+++ b/packaging/rpm/centos/6/.gitignore
@@ -1,5 +1,6 @@
 *.jar
 *.zip
+*.tar.gz
 BUILD/
 BUILDROOT/
 RPMS/

--- a/packaging/rpm/centos/6/SPECS/geowave.spec
+++ b/packaging/rpm/centos/6/SPECS/geowave.spec
@@ -34,6 +34,7 @@ Source8:        namespace.xml
 Source9:        workspace.xml
 Source10:       geowave-ingest-tool.jar
 Source11:       gh-pages.zip
+Source12:       puppet-scripts.tar.gz
 BuildRequires:  unzip
 BuildRequires:  zip
 
@@ -108,6 +109,10 @@ unzip -p %{SOURCE10} geowave-ingest-cmd-completion.sh > %{buildroot}/etc/bash_co
 mkdir -p %{buildroot}%{geowave_docs_home}
 unzip -qq %{SOURCE11} -d %{buildroot}%{geowave_docs_home}
 #TODO: Reformat *.md pages into *.html pages using something like pandoc
+
+# Puppet scripts
+mkdir -p %{buildroot}/etc/puppet/modules
+tar xvzf %{SOURCE12} -C %{buildroot}/etc/puppet/modules
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -252,7 +257,23 @@ fi
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+%package        puppet
+Summary:        GeoWave Puppet Scripts
+Group:          Applications/Internet
+Requires:       puppet-server
+
+%description puppet
+This package installs the geowave Puppet module to /etc/puppet/modules
+
+%files puppet
+%defattr(644, root, root, 755)
+/etc/puppet/modules/geowave
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 %changelog
+* Mon Jan 5 2015 Andrew Spohn <andrew.e.spohn.ctr.nga.mil> - 0.8.2-2
+- Added geowave-puppet rpm
 * Fri Jan 2 2015 Andrew Spohn <andrew.e.spohn.ctr.nga.mil> - 0.8.2-1
 - Added a helper script for geowave-ingest and bash command completion
 * Wed Nov 19 2014 Andrew Spohn <andrew.e.spohn.ctr.nga.mil> - 0.8.2

--- a/packaging/rpm/centos/6/rpm.sh
+++ b/packaging/rpm/centos/6/rpm.sh
@@ -19,7 +19,8 @@ ARTIFACT_01_URL=$LOCAL_JENKINS/job/${ARGS[job]}/lastSuccessfulBuild/artifact/geo
 ARTIFACT_02_URL=$LOCAL_JENKINS/job/${ARGS[job]}/lastSuccessfulBuild/artifact/geowave-deploy/target/geowave-geoserver.jar
 ARTIFACT_03_URL=$LOCAL_JENKINS/job/${ARGS[job]}/lastSuccessfulBuild/artifact/geowave-types/target/geowave-ingest-tool.jar
 ARTIFACT_04_URL=$LOCAL_JENKINS/job/${ARGS[job]}/lastSuccessfulBuild/artifact/geowave-deploy/target/gh-pages.zip
-ARTIFACT_05_URL=$LOCAL_JENKINS/userContent/geoserver/${ARGS[geoserver]}
+ARTIFACT_05_URL=$LOCAL_JENKINS/job/${ARGS[job]}/lastSuccessfulBuild/artifact/geowave-deploy/target/puppet-scripts.tar.gz
+ARTIFACT_06_URL=$LOCAL_JENKINS/userContent/geoserver/${ARGS[geoserver]}
 RPM_ARCH=noarch
 
 case ${ARGS[command]} in
@@ -34,6 +35,7 @@ case ${ARGS[command]} in
         update_artifact $ARTIFACT_02_URL;
         update_artifact $ARTIFACT_03_URL;
         update_artifact $ARTIFACT_04_URL;
-        update_artifact $ARTIFACT_05_URL geoserver.zip; ;;
+        update_artifact $ARTIFACT_05_URL;
+        update_artifact $ARTIFACT_06_URL geoserver.zip; ;;
         *) about ;;
 esac


### PR DESCRIPTION
For ease of distribution and updating we'll package the GeoWave Puppet scripts and make them available as an RPM. Many folks will just want to extract the scripts from our tarball archive and manage themselves in their SCM (which is fine) Other projects may want or require (Red Disk) that Puppet scripts are managed via RPM.