### PR TITLE
Add puppet doc page and fix archive path error that broke build

### DIFF
--- a/docs/content/086-puppet.adoc
+++ b/docs/content/086-puppet.adoc
@@ -1,0 +1,85 @@
+[[puppet]]
+<<<
+== Puppet
+
+=== Overview
+
+A GeoWave http://puppetlabs.com/[Puppet module^] has been provided as part of both the tar.gz archive bundle and as an
+http://en.wikipedia.org/wiki/RPM_Package_Manager[RPM^]. This module can be used to install the various GeoWave services
+onto separate nodes in a cluster or all onto a single node for development.
+
+=== Options
+
+hadoop_vendor_version::
+The Hadoop framework vendor and version against which GeoWave was built. Currently only cdh5 is supported
+
+install_accumulo::
+Install the GeoWave Accumulo Iterator on this node and upload it into HDFS. This node must have a working HDFS client.
+
+install_app::
+Install the GeoWave ingest utility on this node. This node must have a working HDFS client.
+
+install_app_server::
+Install Jetty with Geoserver and GeoWave plugin on this node.
+
+http_port::
+The port on which the Jetty application server will run, defaults to 8080.
+
+repo_base_url::
+Used with the optional geowave::repo class to point the local package management system at a source for GeoWave RPMs.
+The default location is http://s3.amazonaws.com/geowave-rpms/dev/noarch/
+
+repo_refresh_md::
+The number of seconds before checking for new RPMs. On a production system the default of every 6 hours should be sufficient
+but you can lower this down to 0 for a development system on which you wish to pick up new packages as soon as they are
+made available.
+
+=== Examples
+
+==== Development
+Install everything on a one node development system, use the GeoWave Development RPM Repo and force a check for new RPMs
+with every pull (don't use cached metadata)
+
+[source, ruby]
+----
+# Dev VM
+class { 'geowave::repo':
+  repo_refresh_md => 0,
+} ->
+class { 'geowave':
+  hadoop_vendor_version => 'cdh5',
+  install_accumulo      => true,
+  install_app           => true,
+  install_app_server    => true,
+}
+----
+
+=== Clustered
+Run the application server on a different node, use a locally maintained rpm repo vs. the one available on the Internet and
+run the app server on an alternate port so as not to conflict with another service running on that host.
+[source, ruby]
+----
+# Master Node
+node 'c1-master' {
+  class { 'geowave::repo':
+    repo_base_url   => 'http://my-local-rpm-repo/geowave-rpms/dev/noarch/',
+  } ->
+  class { 'geowave':
+    hadoop_vendor_version => 'cdh5',
+    install_accumulo      => true,
+    install_app           => true,
+  }
+}
+
+# App server node
+node 'c1-app-01' {
+  class { 'geowave::repo':
+    repo_base_url   => 'http://my-local-rpm-repo/geowave-rpms/dev/noarch/',
+  } ->
+  class { 'geowave':
+    hadoop_vendor_version => 'cdh5',
+    install_app_server    => true,
+    http_port             => '8888',
+  }
+}
+----

--- a/docs/content/packages.html
+++ b/docs/content/packages.html
@@ -89,6 +89,10 @@
                                         This package installs the web application server
                                     </li>
                                     <li>
+                                        <b>geowave-*-puppet</b><br/>
+                                        This package installs the GeoWave Puppet module into /etc/puppet/modules on a Puppet Server
+                                    </li>
+                                    <li>
                                         <b>geowave-*-single-host</b><br/>
                                         This package installs all the components on a single host and will likely be useful for dev environments
                                     </li>

--- a/packaging/rpm/admin-scripts/jenkins-build-geowave.sh
+++ b/packaging/rpm/admin-scripts/jenkins-build-geowave.sh
@@ -22,6 +22,4 @@ git fetch --all
 git archive origin/gh-pages --remote=$WORKSPACE --format=zip > $WORKSPACE/geowave-deploy/target/gh-pages.zip
 
 # Copy over the puppet scripts
-pushd $WORKSPACE/packaging/puppet
-tar cvzf $WORKSPACE/geowave-deploy/target/puppet-scripts.tar.gz $WORKSPACE/packaging/puppet/geowave
-popd
+tar -cvzf $WORKSPACE/geowave-deploy/target/puppet-scripts.tar.gz -C $WORKSPACE/packaging/puppet geowave


### PR DESCRIPTION
This patch does the following:
* Fixes the path issue when packaging the puppet scripts in jenkins-build-geowave.sh
* Updates the list of rpms available to include the geowave-puppet rpm
* Adds a documentation page showing examples of how to configure geowave using the puppet module 