### PR TITLE
Refactor geowave-ingest command docs so we can use for manpages as well

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,3 @@
+content/manpages/*.1
+content/manpages/*.xml
+content/manpages/*.text

--- a/docs/content/000-titlepage.adoc
+++ b/docs/content/000-titlepage.adoc
@@ -7,12 +7,12 @@ PDF Generation gives an error if you try to use icons
 ifdef::backend-html5[]
 == Links
 
-=== icon:home[] http://spohnan.github.io/geowave[Site]
+=== icon:home[] http://ngageoint.github.io/geowave/[Site]
 
-=== icon:file-code-o[] http://spohnan.github.io/geowave/apidocs/index.html[Javadoc]
+=== icon:file-code-o[] http://ngageoint.github.io/geowave/apidocs/index.html[Javadoc]
 
 === icon:github[] https://github.com/ngageoint/geowave[GitHub]
 
-=== icon:file-archive-o[] http://spohnan.github.io/geowave/packages.html[RPMs]
+=== icon:file-archive-o[] http://ngageoint.github.io/geowave/packages.html[RPMs]
 
 endif::backend-html5[]

--- a/docs/content/050-framework.adoc
+++ b/docs/content/050-framework.adoc
@@ -11,7 +11,7 @@ First we will show how to build and use the built in types, and after that descr
 This assumes you have already built the main project, if not first do that
 
 [NOTE]
-You should either edit the geowave/pom.xml file for the correct accumulo, hadoop, geotools, and geoserver versions,
+You should either edit the geowave/pom.xml file for the correct Accumulo, Hadoop, GeoTools, and GeoServer versions,
 or supply command line parameters to override them.
 
 [source, bash]
@@ -29,219 +29,44 @@ $ cd geowave-types
 $ mvn package -Pingest-singlejar
 ----
 
-==== Running ingest
+The ingest file is now packaged in target. When packaged for installation there will be a wrapper script named geowave-ingest
+that will be installed in $PATH. In a development environment were this script has not been installed you can use the
+artifact directly with the command ```java -jar geowave-types-VERSION-ingest-tool.jar <operation> <options>```
 
-The ingest file is now packaged in target
-
-[source, bash]
+=== Cmd: geowave-ingest
 ----
-$ java -jar geowave-types-0.8.0-SNAPSHOT-ingest-tool.jar
-usage: <operation> <options>
-
-Operations:
- -clear         clear ALL data from a GeoWave namespace, this actually
-                deletes Accumulo tables prefixed by the given namespace
- -hdfsingest    copy supported files from local file system to HDFS and
-                ingest from HDFS
- -hdfsstage     stage supported files in local file system to HDFS
- -localingest   ingest supported files in local file system directly,
-                without using HDFS
- -poststage     ingest supported files that already exist in HDFS
-
-Options are specific to operation choice. Use <operation> -h for help.
+include::manpages/geowave-ingest.text[]
 ----
 
-Okay, so what do these options mean? We will go into each in more detail, but basically the ingest plugin supports two
-types of ingest. Local, and HDFS. Which you use probably depends on the type and amount of data you need to load. The
-framework handles abstracting across the two methods, so you only need to write the code once.
-
-The hdfsingest option is actually just the hdfsstage and poststage methods chained together. Using them separately is
-useful if you have a use case to ingest the same data multiple times from hdfs, or if you have a process that has already
-loaded the data into hdfs.
-
-Each plugin in the ingest framework is required to identify the type of files it can ingest. The coarse filter is based
-on file extension, and then a secondary filter can be created based on reading the contents of the file.
-
-The intent is to allow the user to point to a directory of files and for the framework to discover and ingest all
-possible types. The user can explicitly select only certain plugins if they need to narrow this down.
-
-Now for more details:
-
-
-==== Option: -clear
-
-[source, bash]
+=== Operation: -clear
 ----
-$ java -jar geowave-types-0.8.0-SNAPSHOT-ingest-tool.jar -clear -h
-usage: -clear <options>
-
-Options:
- -c,--clear               Clear ALL data stored with the same prefix as
-                          this namespace (optional; default is to append
-                          data to the namespace if it exists)
- -h,--help                Display help
- -i,--instance-id <arg>   The Accumulo instance ID
- -index,--index <arg>     The type of index, either 'spatial' or
-                          'spatial-temporal' (optional; default is
-                          'spatial')
- -l,--list                List the available ingest types
- -n,--namespace <arg>     The table namespace (optional; default is no
-                          namespace)
- -p,--password <arg>      The password for the user
- -t,--types <arg>         Explicitly set the ingest type by name (or
-                          multiple comma-delimited types), if not set all
-                          available ingest types will be used
- -u,--user <arg>          A valid Accumulo user ID
- -v,--visibility <arg>    The visiblity of the data ingested (optional;
-                          default is 'public')
- -z,--zookeepers <arg>    A comma-separated list of zookeeper servers that
-                          an Accumulo instance is using
+include::manpages/geowave-ingest-clear.text[]
 ----
 
-This option will delete all geowave data stored in accumulo for the
-provided dataset. Required parameters for this command are
-
-* zookeepers
-* accumulo instance id
-* accumulo user id
-* accumulo password
-* geowave namespace
-
-==== Option: -localingest
-
-This runs the ingest code (parse to features, load features to accumulo)
-all locally.
-
-[source, bash]
+=== Operation: -hdfsingest
 ----
-$ java -jar geowave-types-0.8.0-SNAPSHOT-ingest-tool.jar  -localingest -h
-usage: -localingest <options>
-
-Options:
- -b,--base <arg>          Base input file or directory to crawl with one
-                          of the supported ingest types
- -c,--clear               Clear ALL data stored with the same prefix as
-                          this namespace (optional; default is to append
-                          data to the namespace if it exists)
- -h,--help                Display help
- -i,--instance-id <arg>   The Accumulo instance ID
- -index,--index <arg>     The type of index, either 'spatial' or
-                          'spatial-temporal' (optional; default is
-                          'spatial')
- -l,--list                List the available ingest types
- -n,--namespace <arg>     The table namespace (optional; default is no
-                          namespace)
- -p,--password <arg>      The password for the user
- -t,--types <arg>         Explicitly set the ingest type by name (or
-                          multiple comma-delimited types), if not set all
-                          available ingest types will be used
- -u,--user <arg>          A valid Accumulo user ID
- -v,--visibility <arg>    The visiblity of the data ingested (optional;
-                          default is 'public')
- -x,--extension <arg>     individual or comma-delimited set of file
-                          extensions to accept (optional)
- -z,--zookeepers <arg>    A comma-separated list of zookeeper servers that
-                          an Accumulo instance is using
+include::manpages/geowave-ingest-hdfsingest.text[]
 ----
 
-Most of the options should be pretty self explanatory. The index type uses one of the two predefined index
-implementations. You can perform temporal lookup/filtering with either, but the spatial-temporal includes indexing in
-the primary index - so will be more performant if spatial extents are commonly used when querying data.
-
-Visibility is passed to Accumulo as a string, so you should put whatever you want in here.
-
-The namespace option is the geowave namespace; this will be the prefix of the geowave tables in Accumulo. There are a
-few rules for this that derive from geotools/geoserver as well as accumulo. To keep it simple if you only use alphabet
-characters and "_" (underscore) you will be fine.
-
-The extensions argument allows you to override the plugin types, narrowing the scope of what is passed to the plugins
-
-The types argument allows you to explicitly only use certain plugins.
-
-Finally, the base directory is the root directory that will be scanned on the local system for files to ingest. The
-process will scan all subdirectories under the provided directory.
-
-==== Option -hdfsingest
-
-This option first copies the local files to an Avro record in HDFS, then executes the ingest process as a map-reduce
-job. Data is ingested into Geowave using the GeowaveInputFormat. This is likely to be the fastest ingest method overall
-for data sets of any notable size (or if they have a large ingest/transform cost).
-
-[source, bash]
+=== Operation: -hdfsstage
 ----
-$ java -jar geowave-types-0.8.0-SNAPSHOT-ingest-tool.jar  -hdfsingest -h
-usage: -hdfsingest <options>
-
-Options:
- -b,--base <arg>          Base input file or directory to crawl with one
-                          of the supported ingest types
- -c,--clear               Clear ALL data stored with the same prefix as
-                          this namespace (optional; default is to append
-                          data to the namespace if it exists)
- -h,--help                Display help
- -hdfs <arg>              HDFS hostname and port in the format
-                          hostname:port
- -hdfsbase <arg>          fully qualified path to the base directory in
-                          hdfs
- -i,--instance-id <arg>   The Accumulo instance ID
- -index,--index <arg>     The type of index, either 'spatial' or
-                          'spatial-temporal' (optional; default is
-                          'spatial')
- -jobtracker <arg>        Hadoop job tracker hostname and port in the
-                          format hostname:port
- -l,--list                List the available ingest types
- -n,--namespace <arg>     The table namespace (optional; default is no
-                          namespace)
- -p,--password <arg>      The password for the user
- -t,--types <arg>         Explicitly set the ingest type by name (or
-                          multiple comma-delimited types), if not set all
-                          available ingest types will be used
- -u,--user <arg>          A valid Accumulo user ID
- -v,--visibility <arg>    The visiblity of the data ingested (optional;
-                          default is 'public')
- -x,--extension <arg>     individual or comma-delimited set of file
-                          extensions to accept (optional)
- -z,--zookeepers <arg>    A comma-separated list of zookeeper servers that
-                          an Accumulo instance is using
+include::manpages/geowave-ingest-hdfsstage.text[]
 ----
 
-The options here are, for the most part, same as for localingest, with a few additions.
+=== Operation: -localingest
+----
+include::manpages/geowave-ingest-localingest.text[]
+----
 
-The hdfs argument should be the hostname and port, so something like "hdfs-namenode.cluster1.com:8020".
-
-The hdfsbase argument is the root path in hdfs that will serve as the base for the stage location. If the directory
-doesn't exist it will be created. The actual ingest file will be created in a "type" (plugin type - seen with the --list
-option) subdirectory under this base directory.
-
-The jobtracker argument is the hostname and port for the jobtracker, so something like mapreduce-namenode.cluster1.com:8021
-
-The hdfsstage and poststage options will just be subsets of this comment; the first creating an avro file in hdfs,
-the second reading this avro file and ingesting into geowave
+=== Operation: -poststage
+----
+include::manpages/geowave-ingest-poststage.text[]
+----
 
 ==== Ingesting all the things
 
-What can we ingest?
-
-[source, bash]
-----
-$ java -jar geowave-types-0.8.0-SNAPSHOT-ingest-tool.jar  -localingest --list
-Available ingest types currently registered as plugins:
-
-tdrive:
-     files from Microsoft Research T-Drive trajectory data set
-
-geotools:
-     all file-based datastores supported within geotools
-
-geolife:
-     files from Microsoft Research GeoLife trajectory data set
-
-gpx:
-     xml files adhering to the schema of gps exchange format
-----
-
-Let's start out with the geotools datastore; this wraps a bunch of geotools supported formats. We will use the
-shapefile capability for our example here.
+We can ingest any data type that has been listed as an ingest plugin. Let's start out with the GeoTools datastore; this
+wraps a bunch of GeoTools supported formats. We will use the shapefile capability for our example here.
 
 ==== Something recognizable
 
@@ -249,7 +74,7 @@ The naturalearthdata side has a few shapefile we can use use. On the page
 http://www.naturalearthdata.com/downloads/50m-cultural-vectors/[50m Cultural Vectors]
 
 Let's download the Admin 0 - Countries shapefile:
-http//www.naturalearthdata.com/download/50m/cultural/ne_50m_admin_0_countries.zip[ne_50m_admin_0_countries.zip]
+http://www.naturalearthdata.com/download/50m/cultural/ne_50m_admin_0_countries.zip[ne_50m_admin_0_countries.zip]
 
 Okay, let's ingest this. I'll take some liberty with the file locations,
 but the process should be obvious
@@ -262,5 +87,5 @@ $ cd ingest
 $ unzip ne_50m_admin_0_countries.zip
 $ rm ne_50m_admin_0_countries.zip
 $ cd ..
-$ java -jar geowave-types-0.8.0-SNAPSHOT-ingest-tool.jar -localingest -b ./ingest -i instance -n adminborders -p pass -t geotools-vector -u user -z zooo-1:2181
+$ geowave-ingest -localingest -b ./ingest -i instance -n adminborders -p pass -t geotools-vector -u user -z zoo-1:2181
 ----

--- a/docs/content/060-ingestplugins.adoc
+++ b/docs/content/060-ingestplugins.adoc
@@ -5,7 +5,7 @@ The geowave-types project comes with several plugins out of the box
 
 [source, bash]
 ----
-$ java -jar geowave-types-0.8.0-SNAPSHOT-ingest-tool.jar  -localingest --list
+$ geowave-ingest -localingest --list
 Available ingest types currently registered as plugins:
 
 tdrive:

--- a/docs/content/manpages/geowave-ingest-clear.adoc
+++ b/docs/content/manpages/geowave-ingest-clear.adoc
@@ -1,0 +1,50 @@
+geowave-ingest-clear(1)
+=======================
+:doctype: manpage
+
+NAME
+----
+geowave-ingest-clear - Delete existing GeoWave content from Accumulo
+
+SYNOPSIS
+--------
+*geowave-ingest -clear* <options>
+
+DESCRIPTION
+-----------
+FOO FOO FOO - The geowave-ingest -clear(1) operator will delete all GeoWave data stored in Accumulo for the provided data set
+
+OPTIONS
+-------
+-c, --clear::
+Clear ALL data stored with the same prefix as this namespace (optional; default is to append data to the namespace if it exists)
+
+-dim, --dimensionality <arg>::
+The dimensionality type for the index, either 'spatial' or 'spatial-temporal' (optional; default is 'spatial')
+
+-h, --help::
+Display help
+
+-i, --instance-id <arg>::
+The Accumulo instance ID
+
+-l, --list::
+List the available ingest types
+
+-n, --namespace <arg>::
+The table namespace (optional; default is no namespace)
+
+-p, --password <arg>::
+The password for the user
+
+-t, --types <arg>::
+Explicitly set the ingest type by name (or multiple comma-delimited types), if not set all available ingest types will be used
+
+-u, --user <arg>::
+A valid Accumulo user ID
+
+-v, --visibility <arg>::
+The visibility of the data ingested (optional; default is 'public')
+
+-z, --zookeepers <arg>::
+A comma-separated list of zookeeper servers that an Accumulo instance is using

--- a/docs/content/manpages/geowave-ingest-hdfsingest.adoc
+++ b/docs/content/manpages/geowave-ingest-hdfsingest.adoc
@@ -1,0 +1,85 @@
+geowave-ingest-hdfsingest(1)
+=============================
+:doctype: manpage
+
+NAME
+----
+geowave-ingest-hdfsingest - Load content from an HDFS file system
+
+SYNOPSIS
+--------
+*geowave-ingest -hdfsingest* <options>
+
+DESCRIPTION
+-----------
+The geowave-ingest -hdfsingest(1) operator first copies the local files to an Avro record in HDFS, then executes the
+ingest process as a map-reduce job. Data is ingested into Geowave using the GeowaveInputFormat. This is likely to be
+the fastest ingest method overall for data sets of any notable size (or if they have a large ingest/transform cost).
+
+OPTIONS
+-------
+-b, --base <arg>::
+Base input file or directory to crawl with one of the supported ingest types
+
+-c, --clear::
+Clear ALL data stored with the same prefix as this namespace (optional; default is to append data to the namespace if it exists)
+
+-dim, --dimensionality <arg>::
+The dimensionality type for the index, either 'spatial' or 'spatial-temporal' (optional; default is 'spatial')
+
+-h, --help::
+Display help
+
+-hdfs <arg>::
+HDFS hostname and port in the format hostname:port
+
+-hdfsbase <arg>::
+The fully qualified path to the base directory in HDFS
+
+-i, --instance-id <arg>::
+The Accumulo instance ID
+
+-jobtracker <arg>::
+Hadoop job tracker hostname and port in the format hostname:port
+
+-l, --list::
+List the available ingest types
+
+-n, --namespace <arg>::
+The table namespace (optional; default is no namespace)
+
+-p, --password <arg>::
+The password for the user
+
+-resourceman <arg>::
+YARN resource manager hostname and port in the format hostname:port
+
+-t, --types <arg>::
+Explicitly set the ingest type by name (or multiple comma-delimited types), if not set all available ingest types will be used
+
+-u, --user <arg>::
+A valid Accumulo user ID
+
+-v, --visibility <arg>::
+The visibility of the data ingested (optional; default is 'public')
+
+-x, --extension <arg>::
+Individual or comma-delimited set of file extensions to accept (optional)
+
+-z, --zookeepers <arg>::
+A comma-separated list of zookeeper servers that an Accumulo instance is using
+
+ADDITIONAL
+----------
+The options here are, for the most part, same as for *geowave-ingest -localingest*, with a few additions.
+
+The hdfs argument should be the hostname and port, so something like "hdfs-namenode.cluster1.com:8020".
+
+The hdfsbase argument is the root path in hdfs that will serve as the base for the stage location. If the directory
+doesn't exist it will be created. The actual ingest file will be created in a "type" (plugin type - seen with the --list
+option) subdirectory under this base directory.
+
+The jobtracker argument is the hostname and port for the jobtracker, so something like mapreduce-namenode.cluster1.com:8021
+
+The hdfsstage and poststage options will just be subsets of this comment; the first creating an avro file in hdfs,
+the second reading this avro file and ingesting into GeoWave

--- a/docs/content/manpages/geowave-ingest-hdfsstage.adoc
+++ b/docs/content/manpages/geowave-ingest-hdfsstage.adoc
@@ -1,0 +1,38 @@
+geowave-ingest-hdfsstage(1)
+=============================
+:doctype: manpage
+
+NAME
+----
+geowave-ingest-hdfsstage - Load supported content from a local file system into HDFS
+
+SYNOPSIS
+--------
+*geowave-ingest -hdfsstage* <options>
+
+DESCRIPTION
+-----------
+The geowave-ingest -hdfsstage(1) operator copies the local files to an Avro record in HDFS
+
+OPTIONS
+-------
+-b,--base <arg>::
+Base input file or directory to crawl with one of the supported ingest types
+
+-h,--help::
+Display help
+
+-hdfs <arg>::
+HDFS hostname and port in the format hostname:port
+
+-hdfsbase <arg>::
+Fully qualified path to the base directory in hdfs
+
+-l, --list::
+List the available ingest types
+
+-t, --types <arg>::
+Explicitly set the ingest type by name (or multiple comma-delimited types), if not set all available ingest types will be used
+
+-x, --extension <arg>::
+Individual or comma-delimited set of file extensions to accept (optional)

--- a/docs/content/manpages/geowave-ingest-localingest.adoc
+++ b/docs/content/manpages/geowave-ingest-localingest.adoc
@@ -1,0 +1,100 @@
+geowave-ingest-localingest(1)
+=============================
+:doctype: manpage
+
+NAME
+----
+geowave-ingest-localingest - Load content from local file system
+
+SYNOPSIS
+--------
+*geowave-ingest -localingest* <options>
+
+DESCRIPTION
+-----------
+The geowave-ingest -localingest(1) operator will run the ingest code (parse to features, load features to accumulo)
+against local file system content.
+
+OPTIONS
+-------
+-b, --base <arg>::
+Base input file or directory to crawl with one of the supported ingest types
+
+-c, --clear::
+Clear ALL data stored with the same prefix as this namespace (optional; default is to append data to the namespace if it exists)
+
+-dim, --dimensionality <arg>::
+The dimensionality type for the index, either 'spatial' or 'spatial-temporal' (optional; default is 'spatial')
+
+-h, --help::
+Display help
+
+-i, --instance-id <arg>::
+The Accumulo instance ID
+
+-l, --list::
+List the available ingest types
+
+-n, --namespace <arg>::
+The table namespace (optional; default is no namespace)
+
+-p, --password <arg>::
+The password for the user
+
+-t, --types <arg>::
+Explicitly set the ingest type by name (or multiple comma-delimited types), if not set all available ingest types will be used
+
+-u, --user <arg>::
+A valid Accumulo user ID
+
+-v, --visibility <arg>::
+The visibility of the data ingested (optional; default is 'public')
+
+-x, --extension <arg>::
+Individual or comma-delimited set of file extensions to accept (optional)
+
+-z, --zookeepers <arg>::
+A comma-separated list of zookeeper servers that an Accumulo instance is using
+
+ADDITIONAL
+----------
+The index type uses one of the two predefined index implementations. You can perform temporal lookup/filtering with
+either, but the spatial-temporal includes indexing in the primary index - so will be more performant if spatial extents
+are commonly used when querying data.
+
+Visibility is passed to Accumulo as a string, so you should put whatever you want in here.
+
+The namespace option is the GeoWave namespace; this will be the prefix of the GeoWave tables in Accumulo. There are a
+few rules for this that derive from geotools/geoserver as well as Accumulo. To keep it simple if you only use alphabet
+characters and "_" (underscore) you will be fine.
+
+The extensions argument allows you to override the plugin types, narrowing the scope of what is passed to the plugins
+
+The types argument allows you to explicitly only use certain plugins.
+
+Finally, the base directory is the root directory that will be scanned on the local system for files to ingest. The
+process will scan all subdirectories under the provided directory.
+
+EXAMPLES
+--------
+List all of the currently registered as ingest type plugins:
+
+*geowave-ingest -localingest --list*::
+
+geotools-vector:
+     all file-based vector datastores supported within geotools
+
+tdrive:
+     files from Microsoft Research T-Drive trajectory data set
+
+geolife:
+     files from Microsoft Research GeoLife trajectory data set
+
+gpx:
+     xml files adhering to the schema of gps exchange format
+
+geotools-raster:
+     all file-based raster formats supported within geotools
+
+Load some load data::
+geowave-ingest -localingest -b ./ingest -i instance -n adminborders -p pass -t geotools-vector -u user -z zoo-1:2181

--- a/docs/content/manpages/geowave-ingest-poststage.adoc
+++ b/docs/content/manpages/geowave-ingest-poststage.adoc
@@ -1,0 +1,63 @@
+geowave-ingest-poststage(1)
+=============================
+:doctype: manpage
+
+NAME
+----
+geowave-ingest-poststage - Ingest supported content that has already been staged in HDFS
+
+SYNOPSIS
+--------
+*geowave-ingest -poststage* <options>
+
+DESCRIPTION
+-----------
+The geowave-ingest -poststage(1) operator executes the ingest process as a map-reduce job using data that has already
+been staged in an HDFS file system
+
+OPTIONS
+-------
+-c, --clear::
+Clear ALL data stored with the same prefix as this namespace (optional; default is to append data to the namespace if it exists)
+
+-dim, --dimensionality <arg>::
+The dimensionality type for the index, either 'spatial' or 'spatial-temporal' (optional; default is 'spatial')
+
+-h, --help::
+Display help
+
+-hdfs <arg>::
+HDFS hostname and port in the format hostname:port
+
+-hdfsbase <arg>::
+Fully qualified path to the base directory in HDFS
+
+-i, --instance-id <arg>::
+The Accumulo instance ID
+
+-jobtracker <arg>::
+Hadoop job tracker hostname and port in the format hostname:port
+
+-l, --list::
+List the available ingest types
+
+-n, --namespace <arg>::
+The table namespace (optional; default is no namespace)
+
+-p, --password <arg>::
+The password for the user
+
+-resourceman <arg>::
+YARN resource manager hostname and port in the format hostname:port
+
+-t, --types <arg>::
+Explicitly set the ingest type by name (or multiple comma-delimited types), if not set  all available ingest types will be used
+
+-u, --user <arg>::
+A valid Accumulo user ID
+
+-v, --visibility <arg>::
+The visibility of the data ingested (optional; default is 'public')
+
+-z,--zookeepers <arg>::
+A comma-separated list of zookeeper servers that an Accumulo instance is using

--- a/docs/content/manpages/geowave-ingest.adoc
+++ b/docs/content/manpages/geowave-ingest.adoc
@@ -1,0 +1,50 @@
+geowave-ingest(1)
+=================
+:doctype: manpage
+
+NAME
+----
+geowave-ingest - Ingest data from a local file system or HDFS into GeoWave
+
+SYNOPSIS
+--------
+*geowave-ingest* <operation> <options>
+
+DESCRIPTION
+-----------
+The geowave-ingest(1) command will ingest data from a local file system or HDFS into GeoWave
+
+OPERATIONS
+----------
+-clear::
+Clear ALL data from a GeoWave namespace, this actually deletes Accumulo tables prefixed by the given namespace
+
+-hdfsingest::
+Copy supported files from local file system to HDFS and ingest from HDFS
+
+-hdfsstage::
+stage supported files in local file system to HDFS
+
+-localingest::
+ingest supported files in local file system directly, without using HDFS
+
+-poststage::
+ingest supported files that already exist in HDFS
+
+ADDITIONAL
+----------
+
+Options are specific to operation choice. Use <operation> -h for help.
+
+The ingest plugin supports two types of ingest, Local and HDFS. Which you use probably depends on the type and amount of
+data you need to load. The framework handles abstracting across the two methods, so you only need to write the code once.
+
+The hdfsingest option is actually just the hdfsstage and poststage methods chained together. Using them separately is
+useful if you have a use case to ingest the same data multiple times from hdfs, or if you have a process that has already
+loaded the data into hdfs.
+
+Each plugin in the ingest framework is required to identify the type of files it can ingest. The coarse filter is based
+on file extension, and then a secondary filter can be created based on reading the contents of the file.
+
+The intent is to allow the user to point to a directory of files and for the framework to discover and ingest all
+possible types. The user can explicitly select only certain plugins if they need to narrow this down.

--- a/packaging/rpm/admin-scripts/jenkins-build-geowave.sh
+++ b/packaging/rpm/admin-scripts/jenkins-build-geowave.sh
@@ -17,9 +17,16 @@ cd $WORKSPACE/geowave-types
 mvn package -Pingest-singlejar $BUILD_ARGS
 mv $WORKSPACE/geowave-types/target/*-ingest-tool.jar $WORKSPACE/geowave-types/target/geowave-ingest-tool.jar
 
+# Text version of man pages for inclusion into HTML/PDF docs
+for file in `ls $WORKSPACE/docs/content/manpages/*.adoc`; do
+  a2x -f text $file -D $WORKSPACE/docs/content/manpages/
+done
 # Build the docs
-git fetch --all
-git archive origin/gh-pages --remote=$WORKSPACE --format=zip > $WORKSPACE/geowave-deploy/target/gh-pages.zip
-
+mvn clean install javadoc:aggregate -DskipITs=true -DskipTests=true
+mvn -P docs -pl docs install
+pushd $WORKSPACE/target/site
+cp -r $WORKSPACE/docs/content/manpages/*.adoc $WORKSPACE/target/site/manpages
+tar czf ../site.tar.gz *
+popd
 # Copy over the puppet scripts
 tar -cvzf $WORKSPACE/geowave-deploy/target/puppet-scripts.tar.gz -C $WORKSPACE/packaging/puppet geowave

--- a/packaging/rpm/centos/6/SPECS/geowave.spec
+++ b/packaging/rpm/centos/6/SPECS/geowave.spec
@@ -33,10 +33,11 @@ Source7:        default.xml
 Source8:        namespace.xml
 Source9:        workspace.xml
 Source10:       geowave-ingest-tool.jar
-Source11:       gh-pages.zip
+Source11:       site.tar.gz
 Source12:       puppet-scripts.tar.gz
 BuildRequires:  unzip
 BuildRequires:  zip
+BuildRequires:  xmlto
 
 %description
 GeoWave provides geospatial and temporal indexing on top of Accumulo.
@@ -108,8 +109,15 @@ unzip -p %{SOURCE10} geowave-ingest-cmd-completion.sh > %{buildroot}/etc/bash_co
 
 # Copy documentation into place
 mkdir -p %{buildroot}%{geowave_docs_home}
-unzip -qq %{SOURCE11} -d %{buildroot}%{geowave_docs_home}
-#TODO: Reformat *.md pages into *.html pages using something like pandoc
+tar xvzf %{SOURCE11} -C %{buildroot}%{geowave_docs_home}
+
+# Compile and deploy man pages
+mkdir -p %{buildroot}/usr/local/share/man/man1
+for file in `ls %{buildroot}%{geowave_docs_home}/manpages/*.adoc`; do
+  a2x -f manpage $file -D %{buildroot}/usr/local/share/man/man1
+done
+rm -rf %{buildroot}%{geowave_docs_home}/manpages
+rm -f %{buildroot}%{geowave_docs_home}/*.pdfmarks
 
 # Puppet scripts
 mkdir -p %{buildroot}/etc/puppet/modules
@@ -192,7 +200,14 @@ This package installs the GeoWave documentation into the GeoWave directory
 
 %files docs
 %defattr(644, geowave, geowave, 755)
-%{geowave_docs_home}
+%doc %{geowave_docs_home}
+
+%doc %attr(644 root, root) /usr/local/share/man/man1/geowave-ingest.1
+%doc %attr(644 root, root) /usr/local/share/man/man1/geowave-ingest-clear.1
+%doc %attr(644 root, root) /usr/local/share/man/man1/geowave-ingest-hdfsingest.1
+%doc %attr(644 root, root) /usr/local/share/man/man1/geowave-ingest-hdfsstage.1
+%doc %attr(644 root, root) /usr/local/share/man/man1/geowave-ingest-localingest.1
+%doc %attr(644 root, root) /usr/local/share/man/man1/geowave-ingest-poststage.1
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -273,9 +288,11 @@ This package installs the geowave Puppet module to /etc/puppet/modules
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 %changelog
-* Mon Jan 5 2015 Andrew Spohn <andrew.e.spohn.ctr.nga.mil> - 0.8.2-2
+* Thu Jan 15 2015 Andrew Spohn <andrew.e.spohn.ctr@nga.mil> - 0.8.2-3
+- Added man pages
+* Mon Jan 5 2015 Andrew Spohn <andrew.e.spohn.ctr@nga.mil> - 0.8.2-2
 - Added geowave-puppet rpm
-* Fri Jan 2 2015 Andrew Spohn <andrew.e.spohn.ctr.nga.mil> - 0.8.2-1
+* Fri Jan 2 2015 Andrew Spohn <andrew.e.spohn.ctr@nga.mil> - 0.8.2-1
 - Added a helper script for geowave-ingest and bash command completion
-* Wed Nov 19 2014 Andrew Spohn <andrew.e.spohn.ctr.nga.mil> - 0.8.2
+* Wed Nov 19 2014 Andrew Spohn <andrew.e.spohn.ctr@nga.mil> - 0.8.2
 - First packaging


### PR DESCRIPTION
This patch does the following:

* Updates the app site links from a personal branch to the eventual location at ngageoint
  * This commit _does not_ replace our current web site, that will be handled in a future cutover commit once everyone is happy with the state of the docs.
* Refactors the docs for the geowave-ingest command and creates manpages in addition the current HTML and PDF docs
  * Extracts inline command docs and makes them into manpage docs
  * During the RPM build process these manpages will be tranformed into text and included back into the HTML and PDF documentation

So one update location for geowave-ingest command documentation, the manpages, and the content will get included in all doc formats. 

The only caveat with this transformation process is if you create the docs locally by running `mvn -P docs -pl docs install` there will be holes in your HTML/PDF docs where the info on the commands is included as the extra step of transforming the man pages into text will not get executed (the maven plugin can't transform man pages yet, only HTML and PDF) but during a normal RPM build this will all get handled automatically using the a2x Asciidoc command.