### PR TITLE
HDFS upload script should use su instead of sudo -u

### DIFF
--- a/packaging/rpm/centos/6/SOURCES/deploy-geowave-to-hdfs.sh
+++ b/packaging/rpm/centos/6/SOURCES/deploy-geowave-to-hdfs.sh
@@ -30,7 +30,7 @@ fi
 # Check to see if lib directory is already present
 su $HDFS_USER -c "hadoop fs -ls $ACCUMULO_LIB_DIR"
 if [ $? -ne 0 ]; then # Try creating
-    sudo -u $HDFS_USER hadoop fs -mkdir -p $ACCUMULO_LIB_DIR
+    su $HDFS_USER -c "hadoop fs -mkdir -p $ACCUMULO_LIB_DIR"
     if [ $? -ne 0 ]; then
         echo >&2 "Unable to create $ACCUMULO_LIB_DIR directory in hdfs. Aborting."; exit 1;
     fi


### PR DESCRIPTION
I figured out using sudo -u was a problem with our locked down RedHat systems a while back but missed a line when refactoring this script last time.

Background in case anyone is interested in the details of the config issue: http://unix.stackexchange.com/questions/122616/why-do-i-need-a-tty-to-run-sudo-if-i-can-sudo-without-a-password
