### PR TITLE
Fix various path issues and add RPM build requirement

### DIFF
--- a/packaging/rpm/admin-scripts/jenkins-build-geowave.sh
+++ b/packaging/rpm/admin-scripts/jenkins-build-geowave.sh
@@ -6,7 +6,7 @@
 # export BUILD_ARGS=" -Daccumulo.version=1.6.0 -Dhadoop.version=2.3.0-cdh5.0.3 -Dhadoop.version.mr=2.3.0-cdh5.0.3 -Dgeotools.version=11.2 -Dgeoserver.version=2.5.2"
 
 # Build the various artifacts
-cd geowave-deploy
+cd $WORKSPACE/geowave-deploy
 mvn package -P geotools-container-singlejar $BUILD_ARGS
 mv $WORKSPACE/geowave-deploy/target/*-geoserver-singlejar.jar $WORKSPACE/geowave-deploy/target/geowave-geoserver.jar
 
@@ -17,16 +17,16 @@ cd $WORKSPACE/geowave-types
 mvn package -Pingest-singlejar $BUILD_ARGS
 mv $WORKSPACE/geowave-types/target/*-ingest-tool.jar $WORKSPACE/geowave-types/target/geowave-ingest-tool.jar
 
+cd $WORKSPACE/
 # Text version of man pages for inclusion into HTML/PDF docs
 for file in `ls $WORKSPACE/docs/content/manpages/*.adoc`; do
   a2x -f text $file -D $WORKSPACE/docs/content/manpages/
 done
-# Build the docs
-mvn clean install javadoc:aggregate -DskipITs=true -DskipTests=true
+# Build and archive HTML/PDF docs
+mvn install javadoc:aggregate -DskipITs=true -DskipTests=true
 mvn -P docs -pl docs install
-pushd $WORKSPACE/target/site
 cp -r $WORKSPACE/docs/content/manpages/*.adoc $WORKSPACE/target/site/manpages
-tar czf ../site.tar.gz *
-popd
+tar -czf $WORKSPACE/target/site.tar.gz -C $WORKSPACE/target site
+
 # Copy over the puppet scripts
-tar -cvzf $WORKSPACE/geowave-deploy/target/puppet-scripts.tar.gz -C $WORKSPACE/packaging/puppet geowave
+tar -czf $WORKSPACE/geowave-deploy/target/puppet-scripts.tar.gz -C $WORKSPACE/packaging/puppet geowave

--- a/packaging/rpm/centos/6/SPECS/geowave.spec
+++ b/packaging/rpm/centos/6/SPECS/geowave.spec
@@ -38,6 +38,7 @@ Source12:       puppet-scripts.tar.gz
 BuildRequires:  unzip
 BuildRequires:  zip
 BuildRequires:  xmlto
+BuildRequires:  asciidoc
 
 %description
 GeoWave provides geospatial and temporal indexing on top of Accumulo.
@@ -109,7 +110,7 @@ unzip -p %{SOURCE10} geowave-ingest-cmd-completion.sh > %{buildroot}/etc/bash_co
 
 # Copy documentation into place
 mkdir -p %{buildroot}%{geowave_docs_home}
-tar xvzf %{SOURCE11} -C %{buildroot}%{geowave_docs_home}
+tar -xzf %{SOURCE11} -C %{buildroot}%{geowave_docs_home} --strip=1
 
 # Compile and deploy man pages
 mkdir -p %{buildroot}/usr/local/share/man/man1
@@ -121,7 +122,7 @@ rm -f %{buildroot}%{geowave_docs_home}/*.pdfmarks
 
 # Puppet scripts
 mkdir -p %{buildroot}/etc/puppet/modules
-tar xvzf %{SOURCE12} -C %{buildroot}/etc/puppet/modules
+tar -xzf %{SOURCE12} -C %{buildroot}/etc/puppet/modules
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/packaging/rpm/centos/6/rpm.sh
+++ b/packaging/rpm/centos/6/rpm.sh
@@ -18,7 +18,7 @@ done
 ARTIFACT_01_URL=$LOCAL_JENKINS/job/${ARGS[job]}/lastSuccessfulBuild/artifact/geowave-deploy/target/geowave-accumulo.jar
 ARTIFACT_02_URL=$LOCAL_JENKINS/job/${ARGS[job]}/lastSuccessfulBuild/artifact/geowave-deploy/target/geowave-geoserver.jar
 ARTIFACT_03_URL=$LOCAL_JENKINS/job/${ARGS[job]}/lastSuccessfulBuild/artifact/geowave-types/target/geowave-ingest-tool.jar
-ARTIFACT_04_URL=$LOCAL_JENKINS/job/${ARGS[job]}/lastSuccessfulBuild/artifact/geowave-deploy/target/gh-pages.zip
+ARTIFACT_04_URL=$LOCAL_JENKINS/job/${ARGS[job]}/lastSuccessfulBuild/artifact/target/site.tar.gz
 ARTIFACT_05_URL=$LOCAL_JENKINS/job/${ARGS[job]}/lastSuccessfulBuild/artifact/geowave-deploy/target/puppet-scripts.tar.gz
 ARTIFACT_06_URL=$LOCAL_JENKINS/userContent/geoserver/${ARGS[geoserver]}
 RPM_ARCH=noarch


### PR DESCRIPTION
A variety of path issues in the script kept this from building correctly and I forgot to add a build dependency to the RPM spec file. Sorry for the extra bother of another pull request but this should do it for the packaging of the HTML and PDF docs into the RPMs.