### PR TITLE
A number of tweaks to our install materials and docs

### DIFF
--- a/docs/content/050-framework.adoc
+++ b/docs/content/050-framework.adoc
@@ -74,7 +74,7 @@ The naturalearthdata side has a few shapefile we can use use. On the page
 http://www.naturalearthdata.com/downloads/50m-cultural-vectors/[50m Cultural Vectors]
 
 Let's download the Admin 0 - Countries shapefile:
-http://www.naturalearthdata.com/download/50m/cultural/ne_50m_admin_0_countries.zip[ne_50m_admin_0_countries.zip]
+http://naciscdn.org/naturalearth/50m/cultural/ne_50m_admin_0_countries.zip[ne_50m_admin_0_countries.zip]
 
 Okay, let's ingest this. I'll take some liberty with the file locations,
 but the process should be obvious
@@ -87,5 +87,5 @@ $ cd ingest
 $ unzip ne_50m_admin_0_countries.zip
 $ rm ne_50m_admin_0_countries.zip
 $ cd ..
-$ geowave-ingest -localingest -b ./ingest -i instance -n adminborders -p pass -t geotools-vector -u user -z zoo-1:2181
+$ geowave-ingest -localingest -b ./ingest -i ACCUMULO_INSTANCE_NAME -n geowave.50m_admin_0_countries -t geotools-vector -u USERNAME -p PASSWORD -z zoo-1:2181
 ----

--- a/docs/content/076-accumulo-config.adoc
+++ b/docs/content/076-accumulo-config.adoc
@@ -23,9 +23,10 @@ accumulo shell -u root
 createuser geowave // <1>
 createnamespace geowave
 grant NameSpace.CREATE_TABLE -ns geowave -u geowave
-config -s general.vfs.context.classpath.geowave=hdfs://NAME_NODE_FQDN:8020/accumulo/classpath/geowave/geowave-accumulo.jar
+config -s general.vfs.context.classpath.geowave=hdfs://NAME_NODE_FQDN:8020/accumulo/classpath/geowave/[^.].*.jar
 config -ns geowave -s table.classpath.context=geowave
 exit // <2>
+# From the node with the GeoWave application server installed
 java -cp "/usr/local/geowave/geoserver/webapps/geoserver/WEB-INF/lib/*" mil.nga.giat.geowave.vector.plugin.GeoWaveGTDataStore -z ZOOKEEPER_NODE:2181 -i accumulo -u root -p ROOT_PASSWORD -n geowave -m 20
 ----
 <1> You'll be prompted for a password

--- a/docs/content/086-puppet.adoc
+++ b/docs/content/086-puppet.adoc
@@ -8,6 +8,10 @@ A GeoWave http://puppetlabs.com/[Puppet module^] has been provided as part of bo
 RPM. This module can be used to install the various GeoWave services onto separate nodes in a cluster or all onto a single
 node for development.
 
+There are a couple of different RPM repo settings that may need setting. As the repo is disabled by default to avoid picking
+up new Accumulo iterator jars without coordinating a service restart you'll have to enable and then disable in consecutive
+Puppet runs to do the initial install.
+
 === Options
 
 hadoop_vendor_version::
@@ -29,6 +33,10 @@ repo_base_url::
 Used with the optional geowave::repo class to point the local package management system at a source for GeoWave RPMs.
 The default location is http://s3.amazonaws.com/geowave-rpms/dev/noarch/
 
+repo_enabled::
+To pick up an updated Accumulo iterator you'll need to restart the Accumulo service. As we don't want to pick up new
+RPMs with something like a yum-cron job without coordinating a restart so the repo is disabled by default.
+
 repo_refresh_md::
 The number of seconds before checking for new RPMs. On a production system the default of every 6 hours should be sufficient
 but you can lower this down to 0 for a development system on which you wish to pick up new packages as soon as they are
@@ -44,6 +52,7 @@ with every pull (don't use cached metadata)
 ----
 # Dev VM
 class { 'geowave::repo':
+  repo_enabled    => 1,
   repo_refresh_md => 0,
 } ->
 class { 'geowave':
@@ -63,6 +72,7 @@ run the app server on an alternate port so as not to conflict with another servi
 node 'c1-master' {
   class { 'geowave::repo':
     repo_base_url   => 'http://my-local-rpm-repo/geowave-rpms/dev/noarch/',
+    repo_enabled    => 1,
   } ->
   class { 'geowave':
     hadoop_vendor_version => 'cdh5',
@@ -75,6 +85,7 @@ node 'c1-master' {
 node 'c1-app-01' {
   class { 'geowave::repo':
     repo_base_url   => 'http://my-local-rpm-repo/geowave-rpms/dev/noarch/',
+    repo_enabled    => 1,
   } ->
   class { 'geowave':
     hadoop_vendor_version => 'cdh5',
@@ -102,6 +113,6 @@ rest of the cluster using Puppet.
 
 [source, bash]
 ----
-rpm -Uvh http://s3.amazonaws.com/geowave-rpms/dev/noarch/geowave-repo-dev-1.0-2.noarch.rpm
+rpm -Uvh http://s3.amazonaws.com/geowave-rpms/release/noarch/geowave-repo-1.0-3.noarch.rpm
 yum install geowave-cdh5-puppet
 ----

--- a/geowave-ingest/src/main/resources/geowave-ingest.sh
+++ b/geowave-ingest/src/main/resources/geowave-ingest.sh
@@ -7,4 +7,5 @@ else
   JAVA="$JAVA_HOME/bin/java"
 fi
 
-exec $JAVA -jar /usr/local/geowave/ingest/geowave-ingest-tool.jar $@
+# Using -cp and the classname instead of -jar because Java 7 and below fail to auto-launch jars with more than 65k files
+exec $JAVA -cp /usr/local/geowave/ingest/geowave-ingest-tool.jar mil.nga.giat.geowave.ingest.IngestMain $@

--- a/packaging/puppet/geowave/manifests/repo.pp
+++ b/packaging/puppet/geowave/manifests/repo.pp
@@ -1,7 +1,7 @@
 class geowave::repo(
   $repo_name       = 'geowave',
   $repo_desc       = 'GeoWave Repo',
-  $repo_enabled    = 1,
+  $repo_enabled    = 0,
   $repo_base_url   = 'http://s3.amazonaws.com/geowave-rpms/release/noarch/',
   $repo_refresh_md = 21600, # Repo metadata is good for 6 hours by default 
   $repo_priority   = 15,


### PR DESCRIPTION
A number of tweaks to our install materials and docs following the most recent install activity.

* **Ingest script - geowave-ingest.sh**
  * Use java -cp instead of java -jar now that we have more than 65k files in our jar
* **Puppet script - repo.pp**
  * Make the default for GeoWave RPM repo config to be false
* **Doc updates**
  * Update Accumulo classpath config example to use wildcard instead of a specific file name and other minor content clarifications
