### PR TITLE
Added a check to ensure that null iterators aren't attached to accumulo.

### DIFF
--- a/geowave-accumulo/src/main/java/mil/nga/giat/geowave/accumulo/AccumuloDataStore.java
+++ b/geowave-accumulo/src/main/java/mil/nga/giat/geowave/accumulo/AccumuloDataStore.java
@@ -246,14 +246,15 @@ public class AccumuloDataStore implements
 						adapterId);
 			}
 			if (writableAdapter instanceof AttachedIteratorDataAdapter) {
-				if (!DataAdapterAndIndexCache.getInstance(
+				final IteratorConfig[] config = ((AttachedIteratorDataAdapter) writableAdapter).getAttachedIteratorConfig(index);
+				if (config != null && !DataAdapterAndIndexCache.getInstance(
 						AttachedIteratorDataAdapter.ATTACHED_ITERATOR_CACHE_ID).add(
 						writableAdapter.getAdapterId(),
 						indexName)) {
 					accumuloOperations.attachIterators(
 							indexName,
 							accumuloOptions.isCreateTable(),
-							((AttachedIteratorDataAdapter) writableAdapter).getAttachedIteratorConfig(index));
+							config);
 				}
 			}
 			final IngestEntryInfo entryInfo = AccumuloUtils.write(
@@ -430,14 +431,15 @@ public class AccumuloDataStore implements
 						adapterId);
 			}
 			if (dataWriter instanceof AttachedIteratorDataAdapter) {
-				if (!DataAdapterAndIndexCache.getInstance(
+				final IteratorConfig[] config = ((AttachedIteratorDataAdapter) dataWriter).getAttachedIteratorConfig(index);
+				if (config != null && !DataAdapterAndIndexCache.getInstance(
 						AttachedIteratorDataAdapter.ATTACHED_ITERATOR_CACHE_ID).add(
 						dataWriter.getAdapterId(),
 						indexName)) {
 					accumuloOperations.attachIterators(
 							indexName,
 							accumuloOptions.isCreateTable(),
-							((AttachedIteratorDataAdapter) dataWriter).getAttachedIteratorConfig(index));
+							config);
 				}
 			}
 			final List<IngestCallback<T>> callbacks = new ArrayList<IngestCallback<T>>();

--- a/geowave-accumulo/src/main/java/mil/nga/giat/geowave/accumulo/AccumuloIndexWriter.java
+++ b/geowave-accumulo/src/main/java/mil/nga/giat/geowave/accumulo/AccumuloIndexWriter.java
@@ -172,14 +172,15 @@ public class AccumuloIndexWriter implements
 
 		try {
 			if (writableAdapter instanceof AttachedIteratorDataAdapter) {
-				if (!DataAdapterAndIndexCache.getInstance(
+				final IteratorConfig[] config = ((AttachedIteratorDataAdapter) writableAdapter).getAttachedIteratorConfig(index);
+				if (config != null && !DataAdapterAndIndexCache.getInstance(
 						AttachedIteratorDataAdapter.ATTACHED_ITERATOR_CACHE_ID).add(
 						adapterIdObj,
 						indexName)) {
 					accumuloOperations.attachIterators(
 							indexName,
 							accumuloOptions.isCreateTable(),
-							((AttachedIteratorDataAdapter) writableAdapter).getAttachedIteratorConfig(index));
+							config);
 				}
 			}
 			if (accumuloOptions.isUseLocalityGroups() && !accumuloOperations.localityGroupExists(
@@ -292,14 +293,15 @@ public class AccumuloIndexWriter implements
 
 			final byte[] adapterId = writableAdapter.getAdapterId().getBytes();
 			if (writableAdapter instanceof AttachedIteratorDataAdapter) {
-				if (!DataAdapterAndIndexCache.getInstance(
+				final IteratorConfig[] config = ((AttachedIteratorDataAdapter) writableAdapter).getAttachedIteratorConfig(index);
+				if (config != null && !DataAdapterAndIndexCache.getInstance(
 						AttachedIteratorDataAdapter.ATTACHED_ITERATOR_CACHE_ID).add(
 						adapterIdObj,
 						indexName)) {
 					accumuloOperations.attachIterators(
 							indexName,
 							accumuloOptions.isCreateTable(),
-							((AttachedIteratorDataAdapter) writableAdapter).getAttachedIteratorConfig(index));
+							config);
 				}
 			}
 			if (accumuloOptions.isUseLocalityGroups() && !accumuloOperations.localityGroupExists(


### PR DESCRIPTION
This is a quick fix which fixes a bug we encountered during benchmarking.  Accumulo version 1.5.1 will not attach an iterator with a null configuration, but apparently 1.6.0 will.  The code was updated to avoid attaching iterators with null configurations.  