### PR TITLE
Refactor man page generation

### DIFF
--- a/docs/content/manpages/geowave-ingest-clear.adoc
+++ b/docs/content/manpages/geowave-ingest-clear.adoc
@@ -1,5 +1,0 @@
-geowave-ingest-clear(1)
-=======================
-:doctype: manpage
-
-include::manpages/geowave-ingest-clear.txt[]

--- a/docs/content/manpages/geowave-ingest-clear.txt
+++ b/docs/content/manpages/geowave-ingest-clear.txt
@@ -1,16 +1,24 @@
+//:geowave-ingest-clear(1)
+//:=======================
+//::doctype: manpage
+
 NAME
+//:----
 
 geowave-ingest-clear - Delete existing GeoWave content from Accumulo
 
 SYNOPSIS
+//:--------
 
 *geowave-ingest -clear* <options>
 
 DESCRIPTION
+//:-----------
 
 The geowave-ingest -clear(1) operator will delete all GeoWave data stored in Accumulo for the provided data set
 
 OPTIONS
+//:-------
 
 -c, --clear::
 Clear ALL data stored with the same prefix as this namespace (optional; default is to append data to the namespace if it exists)

--- a/docs/content/manpages/geowave-ingest-hdfsingest.adoc
+++ b/docs/content/manpages/geowave-ingest-hdfsingest.adoc
@@ -1,5 +1,0 @@
-geowave-ingest-hdfsingest(1)
-=============================
-:doctype: manpage
-
-include::manpages/geowave-ingest-hdfsingest.txt[]

--- a/docs/content/manpages/geowave-ingest-hdfsingest.txt
+++ b/docs/content/manpages/geowave-ingest-hdfsingest.txt
@@ -1,18 +1,26 @@
+//:geowave-ingest-hdfsingest(1)
+//:============================
+//::doctype: manpage
+
 NAME
+//:----
 
 geowave-ingest-hdfsingest - Load content from an HDFS file system
 
 SYNOPSIS
+//:--------
 
 *geowave-ingest -hdfsingest* <options>
 
 DESCRIPTION
+//:-----------
 
 The geowave-ingest -hdfsingest(1) operator first copies the local files to an Avro record in HDFS, then executes the
 ingest process as a map-reduce job. Data is ingested into Geowave using the GeowaveInputFormat. This is likely to be
 the fastest ingest method overall for data sets of any notable size (or if they have a large ingest/transform cost).
 
 OPTIONS
+//:-------
 
 -b, --base <arg>::
 Base input file or directory to crawl with one of the supported ingest types
@@ -66,6 +74,7 @@ Individual or comma-delimited set of file extensions to accept (optional)
 A comma-separated list of zookeeper servers that an Accumulo instance is using
 
 ADDITIONAL
+//:----------
 
 The options here are, for the most part, same as for *geowave-ingest -localingest*, with a few additions.
 

--- a/docs/content/manpages/geowave-ingest-hdfsstage.adoc
+++ b/docs/content/manpages/geowave-ingest-hdfsstage.adoc
@@ -1,5 +1,0 @@
-geowave-ingest-hdfsstage(1)
-=============================
-:doctype: manpage
-
-include::manpages/geowave-ingest-hdfsstage.txt[]

--- a/docs/content/manpages/geowave-ingest-hdfsstage.txt
+++ b/docs/content/manpages/geowave-ingest-hdfsstage.txt
@@ -1,16 +1,24 @@
+//:geowave-ingest-hdfsstage(1)
+//:===========================
+//::doctype: manpage
+
 NAME
+//:----
 
 geowave-ingest-hdfsstage - Load supported content from a local file system into HDFS
 
 SYNOPSIS
+//:--------
 
 *geowave-ingest -hdfsstage* <options>
 
 DESCRIPTION
+//:-----------
 
 The geowave-ingest -hdfsstage(1) operator copies the local files to an Avro record in HDFS
 
 OPTIONS
+//:-------
 
 -b,--base <arg>::
 Base input file or directory to crawl with one of the supported ingest types

--- a/docs/content/manpages/geowave-ingest-localingest.adoc
+++ b/docs/content/manpages/geowave-ingest-localingest.adoc
@@ -1,5 +1,0 @@
-geowave-ingest-localingest(1)
-=============================
-:doctype: manpage
-
-include::manpages/geowave-ingest-localingest.txt[]

--- a/docs/content/manpages/geowave-ingest-localingest.txt
+++ b/docs/content/manpages/geowave-ingest-localingest.txt
@@ -1,17 +1,25 @@
+//:geowave-ingest-localingest(1)
+//:=============================
+//::doctype: manpage
+
 NAME
+//:----
 
 geowave-ingest-localingest - Load content from local file system
 
 SYNOPSIS
+//:--------
 
 *geowave-ingest -localingest* <options>
 
 DESCRIPTION
+//:-----------
 
 The geowave-ingest -localingest(1) operator will run the ingest code (parse to features, load features to accumulo)
 against local file system content.
 
 OPTIONS
+//:-------
 
 -b, --base <arg>::
 Base input file or directory to crawl with one of the supported ingest types
@@ -53,6 +61,7 @@ Individual or comma-delimited set of file extensions to accept (optional)
 A comma-separated list of zookeeper servers that an Accumulo instance is using
 
 ADDITIONAL
+//:----------
 
 The index type uses one of the two predefined index implementations. You can perform temporal lookup/filtering with
 either, but the spatial-temporal includes indexing in the primary index - so will be more performant if spatial extents
@@ -72,6 +81,7 @@ Finally, the base directory is the root directory that will be scanned on the lo
 process will scan all subdirectories under the provided directory.
 
 EXAMPLES
+//:--------
 
 List all of the currently registered as ingest type plugins:
 

--- a/docs/content/manpages/geowave-ingest-poststage.adoc
+++ b/docs/content/manpages/geowave-ingest-poststage.adoc
@@ -1,5 +1,0 @@
-geowave-ingest-poststage(1)
-=============================
-:doctype: manpage
-
-include::manpages/geowave-ingest-poststage.txt[]

--- a/docs/content/manpages/geowave-ingest-poststage.txt
+++ b/docs/content/manpages/geowave-ingest-poststage.txt
@@ -1,17 +1,25 @@
+//:geowave-ingest-poststage(1)
+//:===========================
+//::doctype: manpage
+
 NAME
+//:----
 
 geowave-ingest-poststage - Ingest supported content that has already been staged in HDFS
 
 SYNOPSIS
+//:--------
 
 *geowave-ingest -poststage* <options>
 
 DESCRIPTION
+//:-----------
 
 The geowave-ingest -poststage(1) operator executes the ingest process as a map-reduce job using data that has already
 been staged in an HDFS file system
 
 OPTIONS
+//:-------
 
 -c, --clear::
 Clear ALL data stored with the same prefix as this namespace (optional; default is to append data to the namespace if it exists)

--- a/docs/content/manpages/geowave-ingest.adoc
+++ b/docs/content/manpages/geowave-ingest.adoc
@@ -1,5 +1,0 @@
-geowave-ingest(1)
-=================
-:doctype: manpage
-
-include::manpages/geowave-ingest.txt[]

--- a/docs/content/manpages/geowave-ingest.txt
+++ b/docs/content/manpages/geowave-ingest.txt
@@ -1,16 +1,24 @@
+//:geowave-ingest(1)
+//:=================
+//::doctype: manpage
+
 NAME
+//:----
 
 geowave-ingest - Ingest data from a local file system or HDFS into GeoWave
 
 SYNOPSIS
+//:--------
 
 *geowave-ingest* <operation> <options>
 
 DESCRIPTION
+//:-----------
 
 The geowave-ingest(1) command will ingest data from a local file system or HDFS into GeoWave
 
 OPERATIONS
+//:----------
 
 -clear::
 Clear ALL data from a GeoWave namespace, this actually deletes Accumulo tables prefixed by the given namespace
@@ -28,7 +36,7 @@ ingest supported files in local file system directly, without using HDFS
 ingest supported files that already exist in HDFS
 
 ADDITIONAL
-
+//:----------
 
 Options are specific to operation choice. Use <operation> -h for help.
 

--- a/packaging/rpm/admin-scripts/jenkins-build-geowave.sh
+++ b/packaging/rpm/admin-scripts/jenkins-build-geowave.sh
@@ -3,7 +3,6 @@
 # GeoWave Jenkins Build Script
 #
 # In the Execute Shell block before calling this script set the versions
-# export BUILD_ARGS=" -Daccumulo.version=1.6.0 -Dhadoop.version=2.3.0-cdh5.0.3 -Dhadoop.version.mr=2.3.0-cdh5.0.3 -Dgeotools.version=11.2 -Dgeoserver.version=2.5.2"
 
 # Build the various artifacts
 cd $WORKSPACE/geowave-deploy
@@ -14,7 +13,7 @@ mvn package -P accumulo-container-singlejar $BUILD_ARGS
 mv $WORKSPACE/geowave-deploy/target/*-accumulo-singlejar.jar $WORKSPACE/geowave-deploy/target/geowave-accumulo.jar
 
 cd $WORKSPACE/geowave-types
-mvn package -Pingest-singlejar $BUILD_ARGS
+mvn package -P ingest-singlejar $BUILD_ARGS
 mv $WORKSPACE/geowave-types/target/*-ingest-tool.jar $WORKSPACE/geowave-types/target/geowave-ingest-tool.jar
 
 # Build and archive HTML/PDF docs
@@ -22,6 +21,13 @@ cd $WORKSPACE/
 mvn install javadoc:aggregate -DskipITs=true -DskipTests=true
 mvn -P docs -pl docs install
 tar -czf $WORKSPACE/target/site.tar.gz -C $WORKSPACE/target site
+
+# Build and archive the man pages
+mkdir -p $WORKSPACE/docs/target/{asciidoc,manpages}
+cp -fR $WORKSPACE/docs/content/manpages/* $WORKSPACE/docs/target/asciidoc
+find $WORKSPACE/docs/target/asciidoc/ -name "*.txt" -exec sed -i "s|//:||" {} \;
+find $WORKSPACE/docs/target/asciidoc/ -name "*.txt" -exec a2x -d manpage -f manpage {} -D $WORKSPACE/docs/target/manpages \;
+tar -czf $WORKSPACE/docs/target/manpages.tar.gz -C $WORKSPACE/docs/target/manpages/ .
 
 # Copy over the puppet scripts
 tar -czf $WORKSPACE/geowave-deploy/target/puppet-scripts.tar.gz -C $WORKSPACE/packaging/puppet geowave

--- a/packaging/rpm/centos/6/SPECS/geowave.spec
+++ b/packaging/rpm/centos/6/SPECS/geowave.spec
@@ -35,6 +35,7 @@ Source9:        workspace.xml
 Source10:       geowave-ingest-tool.jar
 Source11:       site.tar.gz
 Source12:       puppet-scripts.tar.gz
+Source13:       manpages.tar.gz
 BuildRequires:  unzip
 BuildRequires:  zip
 BuildRequires:  xmlto
@@ -112,11 +113,9 @@ unzip -p %{SOURCE10} geowave-ingest-cmd-completion.sh > %{buildroot}/etc/bash_co
 mkdir -p %{buildroot}%{geowave_docs_home}
 tar -xzf %{SOURCE11} -C %{buildroot}%{geowave_docs_home} --strip=1
 
-# Compile and deploy man pages
+# Copy man pages into place
 mkdir -p %{buildroot}/usr/local/share/man/man1
-for file in `ls %{buildroot}%{geowave_docs_home}/manpages/*.adoc`; do
-  a2x -f manpage $file -D %{buildroot}/usr/local/share/man/man1
-done
+tar -xvf %{SOURCE13} -C %{buildroot}/usr/local/share/man/man1
 rm -rf %{buildroot}%{geowave_docs_home}/manpages
 rm -f %{buildroot}%{geowave_docs_home}/*.pdfmarks
 

--- a/packaging/rpm/centos/6/rpm.sh
+++ b/packaging/rpm/centos/6/rpm.sh
@@ -20,7 +20,8 @@ ARTIFACT_02_URL=$LOCAL_JENKINS/job/${ARGS[job]}/lastSuccessfulBuild/artifact/geo
 ARTIFACT_03_URL=$LOCAL_JENKINS/job/${ARGS[job]}/lastSuccessfulBuild/artifact/geowave-types/target/geowave-ingest-tool.jar
 ARTIFACT_04_URL=$LOCAL_JENKINS/job/${ARGS[job]}/lastSuccessfulBuild/artifact/target/site.tar.gz
 ARTIFACT_05_URL=$LOCAL_JENKINS/job/${ARGS[job]}/lastSuccessfulBuild/artifact/geowave-deploy/target/puppet-scripts.tar.gz
-ARTIFACT_06_URL=$LOCAL_JENKINS/userContent/geoserver/${ARGS[geoserver]}
+ARTIFACT_06_URL=$LOCAL_JENKINS/job/${ARGS[job]}/lastSuccessfulBuild/artifact/docs/target/manpages.tar.gz
+ARTIFACT_07_URL=$LOCAL_JENKINS/userContent/geoserver/${ARGS[geoserver]}
 RPM_ARCH=noarch
 
 case ${ARGS[command]} in
@@ -36,6 +37,7 @@ case ${ARGS[command]} in
         update_artifact $ARTIFACT_03_URL;
         update_artifact $ARTIFACT_04_URL;
         update_artifact $ARTIFACT_05_URL;
-        update_artifact $ARTIFACT_06_URL geoserver.zip; ;;
+        update_artifact $ARTIFACT_06_URL;
+        update_artifact $ARTIFACT_07_URL geoserver.zip; ;;
         *) about ;;
 esac


### PR DESCRIPTION
This commit will fix the generation of man pages and keep the source documentation in a single location.

All man page text is now in a single file per command, with all the manpage only markup escaped so other formats can safely include the content. The escaping tokens are removed before transformation into manpages and provided as an archive to the RPM process to simplify that build a bit as well.