### PR TITLE
Sonar plugin version and java doc lint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -313,7 +313,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>sonar-maven-plugin</artifactId>
-                <version>2.1</version>
+                <version>2.5</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -330,6 +330,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>2.9.1</version>
+                <configuration>
+                    <additionalparam>-Xdoclint:none</additionalparam>
+                </configuration>
                 <executions>
                     <execution>
                         <id>aggregate</id>


### PR DESCRIPTION
Addresses ticket #271 which updates the sonar plugin to a version recent enough to work with the newly released Sonar v5 server and disabled JavaDoc doclint checks which now throw errors when run under Java 1.8 instead of warnings.