### PR TITLE
Accumulo iterator versioning docs

### DIFF
--- a/docs/content/085-accumulo-config.adoc
+++ b/docs/content/085-accumulo-config.adoc
@@ -34,3 +34,57 @@ java -cp "/usr/local/geowave/geoserver/webapps/geoserver/WEB-INF/lib/*" mil.nga.
 
 These manual configuration steps have to be performed once after the first install of GeoWave. After the initial install you
 may elect to do further user and namespace creation and configuring to provide isolation between groups and data sets
+
+=== Versioning
+
+It's of critical importance to ensure that the various GeoWave components are all the same version and that your client is of the same version
+that was used to write the data.
+
+==== Basic
+
+The RPM packaged version of GeoWave puts a timestamp in the name so it's pretty easy to verify that you have a matched set of RPMs installed.
+After an update of the components you must restart Accumulo to get vfs to download the new versions and this should keep everything synched.
+
+.Compare version and timestamps of installed RPMs
+[source, bash]
+----
+[spohnae@c1-master ~]$ rpm -qa | grep geowave
+geowave-cdh5-ingest-0.8.4-201503252335.noarch
+geowave-cdh5-core-0.8.4-201503252335.noarch
+geowave-cdh5-accumulo-0.8.4-201503252335.noarch
+geowave-cdh5-docs-0.8.4-201503252335.noarch
+----
+
+==== Advanced
+
+When GeoWave tables are first accessed on a tablet server the vfs classpath tells Accumulo where to download the jar file from HDFS.
+The jar file is copied into the local /tmp directory (the default general.vfs.cache.dir setting anyway) and loaded onto the classpath.
+If there is ever doubt as to if these versions match you can use the commands below from a tablet server node to verify the version of
+this artifact.
+
+.Commit hash of the jar in HDFS
+[source, bash]
+----
+sudo -u hdfs hadoop fs -cat /accumulo/classpath/geowave/geowave-accumulo-build.properties | grep scm.revision | sed s/project.scm.revision=//
+----
+
+.Compare with the versions downloaded locally
+[source, bash]
+----
+sudo find /tmp -name "*geowave-accumulo.jar" -exec unzip -p {} build.properties  \; | grep scm.revision | sed s/project.scm.revision=//
+----
+
+.Example
+[source, bash]
+----
+[spohnae@c1-node-03 ~]$ sudo -u hdfs hadoop fs -cat /accumulo/classpath/geowave/geowave-accumulo-build.properties | grep scm.revision | sed s/project.scm.revision=//
+294ffb267e6691de3b9edc80e312bf5af7b2d23f <1>
+[spohnae@c1-node-03 ~]$ sudo find /tmp -name "*geowave-accumulo.jar" -exec unzip -p {} build.properties  \; | grep scm.revision | sed s/project.scm.revision=//
+294ffb267e6691de3b9edc80e312bf5af7b2d23f <2>
+294ffb267e6691de3b9edc80e312bf5af7b2d23f <2>
+25cf0f895bd0318ce4071a4680d6dd85e0b34f6b
+----
+<1> This is the version loaded into hdfs and should be present on all tablet servers once Accumulo has been restarted
+<2> The find command will probably locate a number of different versions depending on how often you clean out /tmp.
+
+There may be multiple versions copies present, one per JVM, the error scenario is when a tablet server is missing the correct iterator jar.

--- a/packaging/rpm/centos/6/SOURCES/deploy-geowave-to-hdfs.sh
+++ b/packaging/rpm/centos/6/SOURCES/deploy-geowave-to-hdfs.sh
@@ -48,6 +48,17 @@ if [ $? -ne 0 ]; then
     echo >&2 "Unable to upload geowave-accumulo.jar into hdfs. Aborting."; exit 1;
 fi
 
+# Also upload the build metadata file for ease of inspection
+su $HDFS_USER -c "hadoop fs -ls $ACCUMULO_LIB_DIR/geowave-accumulo-build.properties"
+if [ $? -eq 0 ]; then
+    su $HDFS_USER -c "hadoop fs -rm $ACCUMULO_LIB_DIR/geowave-accumulo-build.properties"
+fi
+
+su $HDFS_USER -c "hadoop fs -put $GEOWAVE_ACCUMULO_HOME/geowave-accumulo-build.properties $ACCUMULO_LIB_DIR/geowave-accumulo-build.properties"
+if [ $? -ne 0 ]; then
+    echo >&2 "Unable to upload geowave-accumulo-build.properties into hdfs. Aborting."; exit 1;
+fi
+
 # Set ownership to Accumulo user
 su $HDFS_USER -c "hadoop fs -chown -R $ACCUMULO_USER $ACCUMULO_LIB_DIR"
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
After my recent goof with matching versions I was trying to think of a slightly faster way to check a tablet server. 

The RPM could upload the build.properties file we already install into the local file system along with the iterator jar into hdfs so we could more easily verify what's in hdfs using hadoop fs -cat (no need to unzip anything). This combined with some suggested one-liners in the docs would allow us to compare hdfs to the locally downloaded vfs jars.
