### PR TITLE
Findbugs; add to verify phase, address current issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ cache:
   directories:
   - $HOME/.m2
 install: "mvn -q clean install javadoc:aggregate -Dfindbugs.skip -Daccumulo.version=${ACCUMULO_VERSION} ${ACCUMULO_LEGACY} -Dhadoop.version=${HADOOP_VERSION} -Dgeotools.version=${GEOTOOLS_VERSION} -Dgeoserver.version=${GEOSERVER_VERSION} -DskipITs=true -DskipTests=true -P ${PLATFORM_VERSION}; .utility/build-docs-site.sh"
-script: "mvn -q verify -Daccumulo.version=${ACCUMULO_VERSION} ${ACCUMULO_LEGACY} -Dhadoop.version=${HADOOP_VERSION} -Dgeotools.version=${GEOTOOLS_VERSION} -Dgeoserver.version=${GEOSERVER_VERSION} -P ${PLATFORM_VERSION}"
+script: "mvn -q -T 2C verify -Daccumulo.version=${ACCUMULO_VERSION} ${ACCUMULO_LEGACY} -Dhadoop.version=${HADOOP_VERSION} -Dgeotools.version=${GEOTOOLS_VERSION} -Dgeoserver.version=${GEOSERVER_VERSION} -P ${PLATFORM_VERSION}"
 before_install:
   - export MAVEN_OPTS="-Xmx512m -XX:MaxPermSize=192m"
   - chmod +x .utility/push-javadoc-to-gh-pages.sh

--- a/geowave-accumulo/src/main/java/mil/nga/giat/geowave/accumulo/mapreduce/input/GeoWaveInputFormat.java
+++ b/geowave-accumulo/src/main/java/mil/nga/giat/geowave/accumulo/mapreduce/input/GeoWaveInputFormat.java
@@ -3,17 +3,10 @@ package mil.nga.giat.geowave.accumulo.mapreduce.input;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.net.InetAddress;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Set;
-import java.util.TreeSet;
 
+import com.google.common.base.*;
 import mil.nga.giat.geowave.accumulo.AccumuloOperations;
 import mil.nga.giat.geowave.accumulo.mapreduce.GeoWaveConfiguratorBase;
 import mil.nga.giat.geowave.accumulo.mapreduce.JobContextAdapterStore;
@@ -482,6 +475,7 @@ public class GeoWaveInputFormat<T extends Writable> extends
 				final String instanceId = instance.getInstanceID();
 				final List<Range> rangeList = new ArrayList<Range>(
 						ranges);
+				Random r = new Random();
 				while (!binRanges(
 						rangeList,
 						getUserName(context),
@@ -506,7 +500,7 @@ public class GeoWaveInputFormat<T extends Writable> extends
 					}
 					tserverBinnedRanges.clear();
 					LOGGER.warn("Unable to locate bins for specified ranges. Retrying.");
-					UtilWaitThread.sleep(100 + (int) (Math.random() * 100));
+					UtilWaitThread.sleep(100 + r.nextInt(101));
 					// sleep randomly between 100 and 200 ms
 					tl.invalidateCache();
 				}
@@ -909,6 +903,28 @@ public class GeoWaveInputFormat<T extends Writable> extends
 				}
 			}
 			return retVal;
+		}
+
+		@Override
+		public boolean equals(
+				Object obj ) {
+			if (obj == null) {
+				return false;
+			}
+			if (!(obj instanceof IntermediateSplitInfo)) {
+				return false;
+			}
+			return this.compareTo((IntermediateSplitInfo) obj) == 0;
+		}
+
+		@Override
+		public int hashCode() {
+			// think this matches the spirit of compareTo
+			int mc = getMaxCardinality();
+			return com.google.common.base.Objects.hashCode(
+					mc,
+					getTotalRangeAtCardinality(mc),
+					super.hashCode());
 		}
 
 		private synchronized BigInteger getTotalRangeAtCardinality(

--- a/geowave-accumulo/src/main/java/mil/nga/giat/geowave/accumulo/mapreduce/output/GeoWaveOutputFormat.java
+++ b/geowave-accumulo/src/main/java/mil/nga/giat/geowave/accumulo/mapreduce/output/GeoWaveOutputFormat.java
@@ -169,7 +169,7 @@ public class GeoWaveOutputFormat extends
 	 * A base class to be used to create {@link RecordWriter} instances that
 	 * write to Accumulo.
 	 */
-	protected class GeoWaveRecordWriter extends
+	protected static class GeoWaveRecordWriter extends
 			RecordWriter<GeoWaveOutputKey, Object>
 	{
 		private final Map<ByteArrayId, IndexWriter> indexWriterCache = new HashMap<ByteArrayId, IndexWriter>();

--- a/geowave-accumulo/src/main/java/mil/nga/giat/geowave/accumulo/util/EntryIteratorWrapper.java
+++ b/geowave-accumulo/src/main/java/mil/nga/giat/geowave/accumulo/util/EntryIteratorWrapper.java
@@ -94,6 +94,9 @@ public class EntryIteratorWrapper<T> implements
 	public T next()
 			throws NoSuchElementException {
 		final T previousNext = nextValue;
+		if (nextValue == null) {
+			throw new NoSuchElementException();
+		}
 		nextValue = null;
 		return previousNext;
 	}

--- a/geowave-accumulo/src/main/java/mil/nga/giat/geowave/accumulo/util/InputFormatIteratorWrapper.java
+++ b/geowave-accumulo/src/main/java/mil/nga/giat/geowave/accumulo/util/InputFormatIteratorWrapper.java
@@ -116,6 +116,9 @@ public class InputFormatIteratorWrapper<T> implements
 	public Entry<GeoWaveInputKey, T> next()
 			throws NoSuchElementException {
 		final Entry<GeoWaveInputKey, T> previousNext = nextValue;
+		if (nextValue == null) {
+			throw new NoSuchElementException();
+		}
 		nextValue = null;
 		return previousNext;
 	}

--- a/geowave-accumulo/src/main/java/mil/nga/giat/geowave/accumulo/util/IteratorWrapper.java
+++ b/geowave-accumulo/src/main/java/mil/nga/giat/geowave/accumulo/util/IteratorWrapper.java
@@ -55,7 +55,7 @@ public class IteratorWrapper<InputType, ConvertedType> implements
 	}
 
 	@Override
-	public boolean hasNext() {
+	public synchronized boolean hasNext() {
 		if (conversionQueue.hasNext()) {
 			return true;
 		}
@@ -91,7 +91,7 @@ public class IteratorWrapper<InputType, ConvertedType> implements
 	}
 
 	@Override
-	public void remove() {
+	public synchronized void remove() {
 		conversionQueue.remove();
 		inputIterator.remove();
 	}

--- a/geowave-accumulo/src/test/java/mil/nga/giat/geowave/accumulo/query/AccumuloRangeQueryTest.java
+++ b/geowave-accumulo/src/test/java/mil/nga/giat/geowave/accumulo/query/AccumuloRangeQueryTest.java
@@ -2,7 +2,6 @@ package mil.nga.giat.geowave.accumulo.query;
 
 import java.util.*;
 
-
 import com.vividsolutions.jts.geom.Polygon;
 import com.vividsolutions.jts.io.ParseException;
 import com.vividsolutions.jts.io.WKBReader;
@@ -135,8 +134,9 @@ public class AccumuloRangeQueryTest
 	}
 
 	/**
-	 * Verifies equality for interning is still working as expected (topologically),
-	 * as the the largeQuery() test has a dependency on this;
+	 * Verifies equality for interning is still working as expected
+	 * (topologically), as the the largeQuery() test has a dependency on this;
+	 * 
 	 * @throws ParseException
 	 */
 	@Test
@@ -189,10 +189,18 @@ public class AccumuloRangeQueryTest
 		final Geometry gSerialized = wkbReader.read(b);
 		final Geometry gSerializedArrayCopy = wkbReader.read(b2);
 
-		Assert.assertEquals(g, gNewInstance);
-		Assert.assertEquals(g, gSerializedArrayCopy);
-		Assert.assertEquals(gSerialized, gSerializedArrayCopy);
-		Assert.assertEquals(gSerialized, gSerializedArrayCopy);
+		Assert.assertEquals(
+				g,
+				gNewInstance);
+		Assert.assertEquals(
+				g,
+				gSerializedArrayCopy);
+		Assert.assertEquals(
+				gSerialized,
+				gSerializedArrayCopy);
+		Assert.assertEquals(
+				gSerialized,
+				gSerializedArrayCopy);
 	}
 
 	@Test

--- a/geowave-analytics/pom.xml
+++ b/geowave-analytics/pom.xml
@@ -109,7 +109,7 @@
 			<artifactId>antlr-runtime</artifactId>
 			<version>3.3</version>
 		</dependency>
-		<dependency> 
+		<dependency>
 			<groupId>com.esotericsoftware.kryo</groupId>
 			<artifactId>kryo</artifactId>
 			<version>2.21</version>

--- a/geowave-analytics/src/main/java/mil/nga/giat/geowave/analytics/GaussianFilter.java
+++ b/geowave-analytics/src/main/java/mil/nga/giat/geowave/analytics/GaussianFilter.java
@@ -231,26 +231,6 @@ public class GaussianFilter
 		}
 	}
 
-	public static void main(
-			final String[] args ) {
-		for (int radius = 4; radius >= 1; radius--) {
-			for (int i = -5; i <= 5; i++) {
-				final double sigma = getSigma(
-						radius,
-						i);
-				final double[] kernel = getGaussianKernel(
-						sigma,
-						radius);
-				final StringBuffer buffer = new StringBuffer();
-				for (final double k : kernel) {
-					buffer.append(
-							k).append(
-							", ");
-				}
-			}
-		}
-	}
-
 	protected static double getSigma(
 			final int radius,
 			final int order ) {

--- a/geowave-analytics/src/main/java/mil/nga/giat/geowave/analytics/clustering/DistortionGroupManagement.java
+++ b/geowave-analytics/src/main/java/mil/nga/giat/geowave/analytics/clustering/DistortionGroupManagement.java
@@ -100,6 +100,9 @@ public class DistortionGroupManagement
 						grp.getGroupID());
 			}
 		}
+		catch (final RuntimeException ex) {
+			throw ex;
+		}
 		catch (final Exception ex) {
 			LOGGER.error(
 					"Cannot detremine groups for batch" + parentBatchId,

--- a/geowave-analytics/src/main/java/mil/nga/giat/geowave/analytics/distance/CoordinateCircleDistanceFn.java
+++ b/geowave-analytics/src/main/java/mil/nga/giat/geowave/analytics/distance/CoordinateCircleDistanceFn.java
@@ -12,7 +12,7 @@ public class CoordinateCircleDistanceFn implements
 		DistanceFn<Coordinate>
 {
 
-	protected static CoordinateReferenceSystem DEFAULT_CRS;
+	protected static final CoordinateReferenceSystem DEFAULT_CRS;
 	static {
 		try {
 			DEFAULT_CRS = CRS.decode(

--- a/geowave-analytics/src/main/java/mil/nga/giat/geowave/analytics/kmeans/mapreduce/KMeansDistortionMapReduce.java
+++ b/geowave-analytics/src/main/java/mil/nga/giat/geowave/analytics/kmeans/mapreduce/KMeansDistortionMapReduce.java
@@ -1,8 +1,6 @@
 package mil.nga.giat.geowave.analytics.kmeans.mapreduce;
 
-import java.io.IOException;
-import java.util.List;
-
+import com.vividsolutions.jts.geom.Point;
 import mil.nga.giat.geowave.accumulo.mapreduce.GeoWaveWritableInputMapper;
 import mil.nga.giat.geowave.accumulo.mapreduce.input.GeoWaveInputKey;
 import mil.nga.giat.geowave.analytics.clustering.CentroidManagerGeoWave;
@@ -19,7 +17,7 @@ import mil.nga.giat.geowave.analytics.tools.ConfigurationWrapper;
 import mil.nga.giat.geowave.analytics.tools.SimpleFeatureItemWrapperFactory;
 import mil.nga.giat.geowave.analytics.tools.mapreduce.CountofDoubleWritable;
 import mil.nga.giat.geowave.analytics.tools.mapreduce.JobContextConfigurationWrapper;
-
+import mil.nga.giat.geowave.index.StringUtils;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
 import org.apache.hadoop.io.ObjectWritable;
@@ -28,38 +26,33 @@ import org.apache.hadoop.mapreduce.Mapper;
 import org.apache.hadoop.mapreduce.Reducer;
 import org.apache.log4j.Logger;
 
-import com.vividsolutions.jts.geom.Point;
+import java.io.IOException;
+import java.util.List;
 
 /**
- * 
  * Calculate the distortation.
- * 
+ * <p/>
  * See Catherine A. Sugar and Gareth M. James (2003).
  * "Finding the number of clusters in a data set: An information theoretic approach"
  * Journal of the American Statistical Association 98 (January): 750–763
  * 
- * 
- * @formatter:off
- * 
- *                Context configuration parameters include:
- * 
+ * @formatter:off Context configuration parameters include:
+ *                <p/>
  *                "KMeansDistortionMapReduce.Common.DistanceFunctionClass" ->
  *                {@link mil.nga.giat.geowave.analytics.distance.DistanceFn}
  *                used to determine distance to centroid
- * 
+ *                <p/>
  *                "KMeansDistortionMapReduce.Centroid.WrapperFactoryClass" ->
  *                {@link AnalyticItemWrapperFactory} to extract wrap spatial
  *                objects with Centroid management functions
- * 
+ *                <p/>
  *                "KMeansDistortionMapReduce.Centroid.ExtractorClass" ->
  *                {@link mil.nga.giat.geowave.analytics.extract.CentroidExtractor}
- * 
+ *                <p/>
  *                "KMeansDistortionMapReduce.Jump.CountOfCentroids" -> May be
  *                different from actual.
- * 
- * @see CentroidManagerGeoWave
- * 
  * @formatter:on
+ * @see CentroidManagerGeoWave
  */
 public class KMeansDistortionMapReduce
 {
@@ -249,7 +242,8 @@ public class KMeansDistortionMapReduce
 						new Text(
 								kCount),
 						new Value(
-								distortion.toString().getBytes()));
+								distortion.toString().getBytes(
+										StringUtils.UTF8_CHAR_SET)));
 
 				// write distortion to accumulo, defaults to table given to
 				// AccumuloOutputFormat, in driver

--- a/geowave-analytics/src/main/java/mil/nga/giat/geowave/analytics/kmeans/mapreduce/KSamplerMapReduce.java
+++ b/geowave-analytics/src/main/java/mil/nga/giat/geowave/analytics/kmeans/mapreduce/KSamplerMapReduce.java
@@ -242,7 +242,7 @@ public class KSamplerMapReduce
 			for (final Object value : values) {
 				final AnalyticItemWrapper<T> sampleItem = itemWrapperFactory.create((T) value);
 				Integer outputCount = outputCounts.get(groupID);
-				outputCount = outputCount == null ? 0 : outputCount;
+				outputCount = outputCount == null ? Integer.valueOf(0) : outputCount;
 				if ((outputCount == null) || (outputCount < maxCount)) {
 
 					AnalyticItemWrapper<T> centroid = createCentroid(
@@ -381,7 +381,8 @@ public class KSamplerMapReduce
 		private static String getGroupAsString(
 				final byte[] data ) {
 			return new String(
-					getGroup(data));
+					getGroup(data),
+					StringUtils.UTF8_CHAR_SET);
 		}
 
 		private static byte[] getGroup(
@@ -400,7 +401,7 @@ public class KSamplerMapReduce
 				final double weight,
 				final byte[] dataIdBytes ) {
 			keyBuffer.rewind();
-			final byte[] groupIDBytes = groupID.getBytes();
+			final byte[] groupIDBytes = groupID.getBytes(StringUtils.UTF8_CHAR_SET);
 			// try to reuse
 			final int size = dataIdBytes.length + 16 + groupIDBytes.length;
 			if (keyBuffer.capacity() < size) {

--- a/geowave-analytics/src/main/java/mil/nga/giat/geowave/analytics/kmeans/mapreduce/runners/KMeansDistortionJobRunner.java
+++ b/geowave-analytics/src/main/java/mil/nga/giat/geowave/analytics/kmeans/mapreduce/runners/KMeansDistortionJobRunner.java
@@ -14,6 +14,7 @@ import mil.nga.giat.geowave.analytics.tools.PropertyManagement;
 import mil.nga.giat.geowave.analytics.tools.RunnerUtils;
 import mil.nga.giat.geowave.analytics.tools.mapreduce.CountofDoubleWritable;
 import mil.nga.giat.geowave.analytics.tools.mapreduce.MapReduceJobRunner;
+import mil.nga.giat.geowave.index.StringUtils;
 
 //@formatter:off
 /*if[ACCUMULO_1.5.2]
@@ -21,6 +22,7 @@ import mil.nga.giat.geowave.analytics.tools.mapreduce.MapReduceJobRunner;
 import org.apache.accumulo.core.client.ClientConfiguration;
 /*end[ACCUMULO_1.5.2]*/
 //@formatter:on
+
 import org.apache.accumulo.core.client.mapreduce.AccumuloOutputFormat;
 import org.apache.accumulo.core.client.security.tokens.AuthenticationToken;
 import org.apache.accumulo.core.client.security.tokens.PasswordToken;
@@ -115,8 +117,7 @@ public class KMeansDistortionJobRunner extends
 				job.getConfiguration(),
 				KMeansDistortionMapReduce.class,
 				new Object[] {
-					new Integer(
-							k)
+					Integer.valueOf(k)
 				},
 				new ParameterEnum[] {
 					JumpParameters.Jump.COUNT_OF_CENTROIDS
@@ -158,7 +159,7 @@ public class KMeansDistortionJobRunner extends
 				namespace);
 
 		final AuthenticationToken authToken = new PasswordToken(
-				password.getBytes());
+				password.getBytes(StringUtils.UTF8_CHAR_SET));
 		// set up AccumuloOutputFormat
 		AccumuloOutputFormat.setConnectorInfo(
 				job,

--- a/geowave-analytics/src/main/java/mil/nga/giat/geowave/analytics/kmeans/mapreduce/runners/KMeansJumpJobRunner.java
+++ b/geowave-analytics/src/main/java/mil/nga/giat/geowave/analytics/kmeans/mapreduce/runners/KMeansJumpJobRunner.java
@@ -300,7 +300,7 @@ public class KMeansJumpJobRunner extends
 				SampleParameters.Sample.INDEX_ID);
 	}
 
-	private class KMeansParallelJobRunnerDelegate implements
+	private static class KMeansParallelJobRunnerDelegate implements
 			MapReduceJobRunner
 	{
 		final KMeansSingleSampleJobRunner<SimpleFeature> singleSamplekmeansJobRunner = new KMeansSingleSampleJobRunner<SimpleFeature>();

--- a/geowave-analytics/src/main/java/mil/nga/giat/geowave/analytics/kmeans/mapreduce/runners/StripWeakCentroidsRunner.java
+++ b/geowave-analytics/src/main/java/mil/nga/giat/geowave/analytics/kmeans/mapreduce/runners/StripWeakCentroidsRunner.java
@@ -213,6 +213,25 @@ public class StripWeakCentroidsRunner<T> implements
 			return new Double(
 					(arg0).chg).compareTo(chg);
 		}
+
+		@Override
+		public boolean equals(
+				Object obj ) {
+			if (obj == null) {
+				return false;
+			}
+			if (!(obj instanceof ChangeFromLast)) {
+				return false;
+			}
+			return this.compareTo((ChangeFromLast) obj) == 0;
+		}
+
+		@Override
+		public int hashCode() {
+			return Double.valueOf(
+					chg).hashCode();
+		}
+
 	}
 
 	public static class StableChangeBreakStrategy<T> implements

--- a/geowave-analytics/src/main/java/mil/nga/giat/geowave/analytics/mapreduce/kde/compare/ComparisonAccumuloStatsReducer.java
+++ b/geowave-analytics/src/main/java/mil/nga/giat/geowave/analytics/mapreduce/kde/compare/ComparisonAccumuloStatsReducer.java
@@ -109,7 +109,7 @@ public class ComparisonAccumuloStatsReducer extends
 
 	private Point2d[] fromIndexToLL_UR(
 			final long index ) {
-		final double llLon = ((Math.floor(index / numYPosts) * 360.0) / numXPosts) - 180.0;
+		final double llLon = ((Math.floor(index / (double) numYPosts) * 360.0) / numXPosts) - 180.0;
 		final double llLat = (((index % numYPosts) * 180.0) / numYPosts) - 90.0;
 		final double urLon = llLon + (360.0 / numXPosts);
 		final double urLat = llLat + (180.0 / numYPosts);

--- a/geowave-analytics/src/main/java/mil/nga/giat/geowave/analytics/mapreduce/kde/parser/BasicMathLexer.java
+++ b/geowave-analytics/src/main/java/mil/nga/giat/geowave/analytics/mapreduce/kde/parser/BasicMathLexer.java
@@ -2,11 +2,16 @@ package mil.nga.giat.geowave.analytics.mapreduce.kde.parser;
 
 // $ANTLR 3.3 BasicMath.g 2014-05-13 05:58:45
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.antlr.runtime.*;
 import java.util.Stack;
 import java.util.List;
 import java.util.ArrayList;
 
+@SuppressFBWarnings({
+	"SF_SWITCH_NO_DEFAULT",
+	"SIC_INNER_SHOULD_BE_STATIC"
+})
 @SuppressWarnings("all")
 public class BasicMathLexer extends
 		Lexer

--- a/geowave-analytics/src/main/java/mil/nga/giat/geowave/analytics/mapreduce/kde/parser/BasicMathParser.java
+++ b/geowave-analytics/src/main/java/mil/nga/giat/geowave/analytics/mapreduce/kde/parser/BasicMathParser.java
@@ -5,6 +5,7 @@ package mil.nga.giat.geowave.analytics.mapreduce.kde.parser;
 import java.util.ArrayList;
 import java.util.List;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.antlr.runtime.BitSet;
 import org.antlr.runtime.MismatchedSetException;
 import org.antlr.runtime.NoViableAltException;
@@ -20,6 +21,11 @@ import org.antlr.runtime.tree.RewriteRuleSubtreeStream;
 import org.antlr.runtime.tree.RewriteRuleTokenStream;
 import org.antlr.runtime.tree.TreeAdaptor;
 
+@SuppressFBWarnings({
+	"RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE",
+	"SF_SWITCH_NO_DEFAULT",
+	"DLS_DEAD_LOCAL_STORE"
+})
 @SuppressWarnings("all")
 public class BasicMathParser extends
 		Parser

--- a/geowave-analytics/src/main/java/mil/nga/giat/geowave/analytics/tools/GeometryDataSetGenerator.java
+++ b/geowave-analytics/src/main/java/mil/nga/giat/geowave/analytics/tools/GeometryDataSetGenerator.java
@@ -138,7 +138,7 @@ public class GeometryDataSetGenerator
 		final double max[] = new double[range.length];
 		for (int i = 0; i < range.length; i++) {
 			min[i] = Math.max(
-					minAxis[i] + (minCenterDistanceFactor * (Math.abs(rand.nextInt()) % (range[i] / minCenterDistanceFactor))),
+					minAxis[i] + (minCenterDistanceFactor * (rand.nextInt(Integer.MAX_VALUE) % (range[i] / minCenterDistanceFactor))),
 					minAxis[i]);
 			max[i] = Math.min(
 					min[i] + (minCenterDistanceFactor * range[i]),
@@ -285,7 +285,7 @@ public class GeometryDataSetGenerator
 		 */
 		final int clusterdItemsCount = (int) Math.ceil((minSetSize) * (1.0 - outlierFactor));
 		while (pointSet.size() < clusterdItemsCount) {
-			final int centerPos = Math.abs(rand.nextInt()) % minForCenter.size();
+			final int centerPos = rand.nextInt(Integer.MAX_VALUE) % minForCenter.size();
 
 			pointSet.add(createNewFeature(
 					minForCenter.get(centerPos),
@@ -398,7 +398,7 @@ public class GeometryDataSetGenerator
 
 		final int dims = coordSystem.getDimension();
 
-		final int shapeSize = (Math.abs(rand.nextInt()) % 5) + 1;
+		final int shapeSize = (rand.nextInt(Integer.MAX_VALUE) % 5) + 1;
 		final Coordinate[] shape = new Coordinate[shapeSize > 2 ? shapeSize + 1 : shapeSize];
 		final double[] constrainedMaxAxis = Arrays.copyOf(
 				maxAxis,

--- a/geowave-analytics/src/main/java/mil/nga/giat/geowave/analytics/tools/SimpleFeatureItemWrapperFactory.java
+++ b/geowave-analytics/src/main/java/mil/nga/giat/geowave/analytics/tools/SimpleFeatureItemWrapperFactory.java
@@ -134,8 +134,7 @@ public class SimpleFeatureItemWrapperFactory implements
 				final int level ) {
 			item.setAttribute(
 					ClusterFeatureAttribute.ZOOM_LEVEL.attrName(),
-					new Integer(
-							level));
+					Integer.valueOf(level));
 
 		}
 

--- a/geowave-analytics/src/main/java/mil/nga/giat/geowave/analytics/tools/kryo/FeatureSerializer.java
+++ b/geowave-analytics/src/main/java/mil/nga/giat/geowave/analytics/tools/kryo/FeatureSerializer.java
@@ -6,6 +6,7 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import mil.nga.giat.geowave.vector.adapter.FeatureWritable;
 
 import org.opengis.feature.simple.SimpleFeature;
@@ -19,6 +20,9 @@ public class FeatureSerializer extends
 		Serializer<SimpleFeature>
 {
 
+	@SuppressFBWarnings({
+		"RR_NOT_CHECKED"
+	})
 	@Override
 	public SimpleFeature read(
 			final Kryo arg0,

--- a/geowave-analytics/src/main/java/mil/nga/giat/geowave/analytics/tools/mapreduce/CountofDoubleWritable.java
+++ b/geowave-analytics/src/main/java/mil/nga/giat/geowave/analytics/tools/mapreduce/CountofDoubleWritable.java
@@ -3,6 +3,7 @@ package mil.nga.giat.geowave.analytics.tools.mapreduce;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.io.Serializable;
 
 import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.io.WritableComparable;
@@ -94,7 +95,8 @@ public class CountofDoubleWritable implements
 
 	/** A Comparator optimized for DoubleWritable. */
 	public static class Comparator extends
-			WritableComparator
+			WritableComparator implements
+			Serializable
 	{
 		public Comparator() {
 			super(
@@ -114,7 +116,9 @@ public class CountofDoubleWritable implements
 			double thatValue = readDouble(
 					b2,
 					s2);
-			return (thisValue < thatValue ? -1 : (thisValue == thatValue ? 0 : 1));
+			return Double.compare(
+					thisValue,
+					thatValue);
 		}
 	}
 

--- a/geowave-analytics/src/main/java/mil/nga/giat/geowave/analytics/tools/mapreduce/HadoopOptions.java
+++ b/geowave-analytics/src/main/java/mil/nga/giat/geowave/analytics/tools/mapreduce/HadoopOptions.java
@@ -43,20 +43,19 @@ public class HadoopOptions
 				runTimeProperties.getProperty(MRConfig.YARN_RESOURCE_MANAGER));
 
 		final String name = runTimeProperties.getProperty(MapReduceParameters.MRConfig.CONFIG_FILE);
+
 		if (name != null) {
-			if (name != null) {
-				try {
-					config.addResource(
-							new FileInputStream(
-									name),
-							name);
-				}
-				catch (final IOException ex) {
-					LOGGER.error(
-							"Configuration file " + name + " not found",
-							ex);
-					throw ex;
-				}
+			try (FileInputStream in = new FileInputStream(
+					name)) {
+				config.addResource(
+						in,
+						name);
+			}
+			catch (final IOException ex) {
+				LOGGER.error(
+						"Configuration file " + name + " not found",
+						ex);
+				throw ex;
 			}
 		}
 

--- a/geowave-benchmark/.gitignore
+++ b/geowave-benchmark/.gitignore
@@ -1,2 +1,1 @@
-data
 /target/

--- a/geowave-benchmark/src/main/java/mil/nga/giat/geowave/benchmark/utils/HistogramGenerator.java
+++ b/geowave-benchmark/src/main/java/mil/nga/giat/geowave/benchmark/utils/HistogramGenerator.java
@@ -354,7 +354,6 @@ public class HistogramGenerator
 		final List<Double> featsPerTile10 = new ArrayList<Double>();
 		final Map<Integer, Integer> collsPerTier10 = new HashMap<Integer, Integer>();
 		final Map<Integer, Integer> featsPerTier10 = new HashMap<Integer, Integer>();
-		final int[] hist10 = new int[500];
 		System.out.println("\nQuery 10");
 		int numColls = 0;
 		int numFeatures = 0;
@@ -396,11 +395,6 @@ public class HistogramGenerator
 						tier,
 						coll.size());
 			}
-
-			final int histIdx = Math.min(
-					(int) (coll.size() / 2.0),
-					499);
-			hist10[histIdx]++;
 
 			numColls++;
 			numFeatures += coll.size();
@@ -447,7 +441,6 @@ public class HistogramGenerator
 		final List<Double> featsPerTile10_full = new ArrayList<Double>();
 		final Map<Integer, Integer> collsPerTier10_full = new HashMap<Integer, Integer>();
 		final Map<Integer, Integer> featsPerTier10_full = new HashMap<Integer, Integer>();
-		final int[] hist10_full = new int[500];
 		System.out.println("\nQuery 10 - Full");
 		numColls = 0;
 		numFeatures = 0;
@@ -490,11 +483,6 @@ public class HistogramGenerator
 						coll.size());
 			}
 
-			final int histIdx = Math.min(
-					(int) (coll.size() / 2.0),
-					499);
-			hist10_full[histIdx]++;
-
 			numColls++;
 			numFeatures += coll.size();
 			featsPerTile10_full.add(new Double(
@@ -521,7 +509,6 @@ public class HistogramGenerator
 		System.out.println("Features per Tile (STD): " + new StandardDeviation().evaluate(Doubles.toArray(featsPerTile10_full)));
 
 		// ================================================================================================
-		final Coordinate[] coords11 = new Coordinate[5];
 		coords10[0] = new Coordinate(
 				-119.29923973537691,
 				-66.02765731285959);
@@ -549,7 +536,6 @@ public class HistogramGenerator
 		final List<Double> featsPerTile11 = new ArrayList<Double>();
 		final Map<Integer, Integer> collsPerTier11 = new HashMap<Integer, Integer>();
 		final Map<Integer, Integer> featsPerTier11 = new HashMap<Integer, Integer>();
-		final int[] hist11 = new int[500];
 		System.out.println("\nQuery 11");
 		numColls = 0;
 		numFeatures = 0;
@@ -591,11 +577,6 @@ public class HistogramGenerator
 						tier,
 						coll.size());
 			}
-
-			final int histIdx = Math.min(
-					(int) (coll.size() / 2.0),
-					499);
-			hist11[histIdx]++;
 
 			numColls++;
 			numFeatures += coll.size();
@@ -642,7 +623,6 @@ public class HistogramGenerator
 		final List<Double> featsPerTile11_full = new ArrayList<Double>();
 		final Map<Integer, Integer> collsPerTier11_full = new HashMap<Integer, Integer>();
 		final Map<Integer, Integer> featsPerTier11_full = new HashMap<Integer, Integer>();
-		final int[] hist11_full = new int[500];
 		System.out.println("\nQuery 11 - Full");
 		numColls = 0;
 		numFeatures = 0;
@@ -684,11 +664,6 @@ public class HistogramGenerator
 						tier,
 						coll.size());
 			}
-
-			final int histIdx = Math.min(
-					(int) (coll.size() / 2.0),
-					499);
-			hist11_full[histIdx]++;
 
 			numColls++;
 			numFeatures += coll.size();

--- a/geowave-client/.gitignore
+++ b/geowave-client/.gitignore
@@ -1,2 +1,1 @@
-data
 /target/

--- a/geowave-deploy/.gitignore
+++ b/geowave-deploy/.gitignore
@@ -1,2 +1,1 @@
-data
 /target/

--- a/geowave-examples/.gitignore
+++ b/geowave-examples/.gitignore
@@ -1,2 +1,1 @@
-data
 /target/

--- a/geowave-examples/src/main/java/mil/nga/giat/geowave/examples/ingest/SimpleIngestProducerConsumer.java
+++ b/geowave-examples/src/main/java/mil/nga/giat/geowave/examples/ingest/SimpleIngestProducerConsumer.java
@@ -105,7 +105,7 @@ public class SimpleIngestProducerConsumer extends
 		}
 	}
 
-	protected class FeatureCollection implements
+	protected static class FeatureCollection implements
 			Iterator<SimpleFeature>
 	{
 		private final BlockingQueue<SimpleFeature> queue = new LinkedBlockingQueue<>(

--- a/geowave-index/pom.xml
+++ b/geowave-index/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<artifactId>geowave-parent</artifactId>
@@ -20,10 +21,9 @@
 			<version>4.4</version>
 			<scope>test</scope>
 		</dependency>
-        <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>annotations</artifactId>
-            <version>${findbugs.version}</version>
-        </dependency>
+		<dependency>
+			<groupId>com.google.code.findbugs</groupId>
+			<artifactId>annotations</artifactId>
+		</dependency>
 	</dependencies>
 </project>

--- a/geowave-index/src/main/java/mil/nga/giat/geowave/index/NumericIndexStrategyFactory.java
+++ b/geowave-index/src/main/java/mil/nga/giat/geowave/index/NumericIndexStrategyFactory.java
@@ -24,7 +24,7 @@ public interface NumericIndexStrategyFactory
 	{
 		public static final int LONGITUDE_BITS = 31;
 		public static final int LATITUDE_BITS = 31;
-		public static final NumericDimensionDefinition[] SPATIAL_DIMENSIONS = new NumericDimensionDefinition[] {
+		protected static final NumericDimensionDefinition[] SPATIAL_DIMENSIONS = new NumericDimensionDefinition[] {
 			new LongitudeDefinition(),
 			new LatitudeDefinition(
 					true)

--- a/geowave-index/src/main/java/mil/nga/giat/geowave/index/dimension/bin/TemporalBinningStrategy.java
+++ b/geowave-index/src/main/java/mil/nga/giat/geowave/index/dimension/bin/TemporalBinningStrategy.java
@@ -193,7 +193,10 @@ public class TemporalBinningStrategy implements
 		}
 	}
 
-	@SuppressFBWarnings(value = "SF_SWITCH_FALLTHROUGH", justification = "Fallthrough intentional for time parsing")
+	@SuppressFBWarnings(value = {
+		"SF_SWITCH_FALLTHROUGH",
+		"SF_SWITCH_NO_DEFAULT"
+	}, justification = "Fallthrough intentional for time parsing")
 	private Calendar getStartEpoch(
 			final byte[] binId ) {
 		final String str = StringUtils.stringFromBinary(binId);

--- a/geowave-ingest/pom.xml
+++ b/geowave-ingest/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<artifactId>geowave-parent</artifactId>

--- a/geowave-ingest/src/main/java/mil/nga/giat/geowave/ingest/AbstractCommandLineDriver.java
+++ b/geowave-ingest/src/main/java/mil/nga/giat/geowave/ingest/AbstractCommandLineDriver.java
@@ -1,5 +1,6 @@
 package mil.nga.giat.geowave.ingest;
 
+import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -9,6 +10,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.ServiceLoader;
 
+import mil.nga.giat.geowave.index.StringUtils;
 import org.apache.commons.cli.BasicParser;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.HelpFormatter;
@@ -65,7 +67,7 @@ abstract public class AbstractCommandLineDriver
 
 	public void run(
 			final String[] args )
-					throws ParseException {
+			throws ParseException {
 		final List<IngestTypePluginProviderSpi<?, ?>> pluginProviders = applyArguments(args);
 		runInternal(
 				args,
@@ -103,11 +105,6 @@ abstract public class AbstractCommandLineDriver
 					options,
 					args);
 			if (commandLine.hasOption("h")) {
-				if (commandLine.hasOption("t")) {
-					selectedPluginProviders = getPluginProviders(
-							commandLine,
-							options);
-				}
 				printHelp(
 						options,
 						operation);
@@ -116,7 +113,9 @@ abstract public class AbstractCommandLineDriver
 			else if (commandLine.hasOption("l")) {
 				final HelpFormatter formatter = new HelpFormatter();
 				final PrintWriter pw = new PrintWriter(
-						System.out);
+						new OutputStreamWriter(
+								System.out,
+								StringUtils.UTF8_CHAR_SET));
 				pw.println("Available ingest types currently registered as plugins:\n");
 				for (final Entry<String, IngestTypePluginProviderSpi<?, ?>> pluginProviderEntry : pluginProviderRegistry.entrySet()) {
 					final IngestTypePluginProviderSpi<?, ?> pluginProvider = pluginProviderEntry.getValue();
@@ -186,7 +185,7 @@ abstract public class AbstractCommandLineDriver
 		final List<IngestTypePluginProviderSpi<?, ?>> selectedPluginProviders = new ArrayList<IngestTypePluginProviderSpi<?, ?>>();
 		final String[] pluginProviderNames = commandLine.getOptionValue(
 				"t").split(
-						",");
+				",");
 		for (final String pluginProviderName : pluginProviderNames) {
 			final IngestTypePluginProviderSpi<?, ?> pluginProvider = pluginProviderRegistry.get(pluginProviderName);
 			if (pluginProvider == null) {
@@ -221,11 +220,11 @@ abstract public class AbstractCommandLineDriver
 
 	abstract protected void parseOptionsInternal(
 			final CommandLine commandLine )
-					throws ParseException;
+			throws ParseException;
 
 	abstract protected void applyOptionsInternal(
 			final Options allOptions );
-	
+
 	abstract protected void runInternal(
 			String[] args,
 			List<IngestTypePluginProviderSpi<?, ?>> pluginProviders );

--- a/geowave-ingest/src/main/java/mil/nga/giat/geowave/ingest/MultiStageCommandLineDriver.java
+++ b/geowave-ingest/src/main/java/mil/nga/giat/geowave/ingest/MultiStageCommandLineDriver.java
@@ -12,7 +12,7 @@ import org.apache.commons.cli.ParseException;
  * first stage intermediate data to HDFS and then to ingest it.
  */
 public class MultiStageCommandLineDriver extends
-AbstractCommandLineDriver
+		AbstractCommandLineDriver
 {
 	private final AbstractCommandLineDriver[] orderedStages;
 
@@ -38,7 +38,7 @@ AbstractCommandLineDriver
 	@Override
 	public void parseOptionsInternal(
 			final CommandLine commandLine )
-					throws ParseException {
+			throws ParseException {
 		for (final AbstractCommandLineDriver stage : orderedStages) {
 			stage.parseOptionsInternal(commandLine);
 		}

--- a/geowave-ingest/src/main/java/mil/nga/giat/geowave/ingest/local/AbstractLocalFileDriver.java
+++ b/geowave-ingest/src/main/java/mil/nga/giat/geowave/ingest/local/AbstractLocalFileDriver.java
@@ -26,7 +26,7 @@ import org.apache.log4j.Logger;
  *            file.
  */
 abstract public class AbstractLocalFileDriver<P extends LocalPluginBase, R> extends
-AbstractCommandLineDriver
+		AbstractCommandLineDriver
 {
 	private final static Logger LOGGER = Logger.getLogger(AbstractLocalFileDriver.class);
 	protected LocalInputCommandLineOptions localInput;
@@ -40,7 +40,7 @@ AbstractCommandLineDriver
 	protected void processInput(
 			final Map<String, P> localPlugins,
 			final R runData )
-					throws IOException {
+			throws IOException {
 		if (localInput.getInput() == null) {
 			LOGGER.fatal("Unable to ingest data, base directory or file input not specified");
 			return;
@@ -71,12 +71,12 @@ AbstractCommandLineDriver
 			String typeName,
 			P plugin,
 			R runData )
-					throws IOException;
+			throws IOException;
 
 	@Override
 	protected void parseOptionsInternal(
 			final CommandLine commandLine )
-					throws ParseException {
+			throws ParseException {
 		localInput = LocalInputCommandLineOptions.parseOptions(commandLine);
 	}
 

--- a/geowave-raster/src/main/java/mil/nga/giat/geowave/raster/RasterUtils.java
+++ b/geowave-raster/src/main/java/mil/nga/giat/geowave/raster/RasterUtils.java
@@ -40,6 +40,7 @@ import javax.media.jai.RenderedOp;
 import javax.media.jai.TiledImage;
 import javax.media.jai.operator.ScaleDescriptor;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import mil.nga.giat.geowave.index.sfc.data.MultiDimensionalNumericData;
 import mil.nga.giat.geowave.raster.adapter.RasterDataAdapter;
 import mil.nga.giat.geowave.raster.adapter.merge.nodata.NoDataMergeStrategy;
@@ -314,7 +315,7 @@ public class RasterUtils
 			// coordinates).
 			// j is a dimension in the 'userRange' space (target coordinates).
 			int j = i;
-			if (swapXY && (j <= 1)) {
+			if (swapXY) {
 				j = 1 - j;
 			}
 			double scale = idRangePerDimension[j];
@@ -509,6 +510,9 @@ public class RasterUtils
 				resultEnvelope);
 	}
 
+	@SuppressFBWarnings(value = {
+		"RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT"
+	}, justification = "incorrect; drawImage has side effects")
 	public static BufferedImage toBufferedImage(
 			final Image image,
 			final int type ) {

--- a/geowave-raster/src/main/java/mil/nga/giat/geowave/raster/adapter/RasterDataAdapter.java
+++ b/geowave-raster/src/main/java/mil/nga/giat/geowave/raster/adapter/RasterDataAdapter.java
@@ -1680,6 +1680,21 @@ public class RasterDataAdapter implements
 				SimpleInternationalString.wrap("Background")
 			};
 		}
+
+		@Override
+		public boolean equals(
+				Object obj ) {
+			if (!(obj instanceof SimplifiedGridSampleDimension)) {
+				return false;
+			}
+			return super.equals(obj);
+		}
+
+		@Override
+		public int hashCode() {
+			return super.hashCode();
+		}
+
 	}
 
 	private static class InternalWritableRaster extends

--- a/geowave-raster/src/main/java/mil/nga/giat/geowave/raster/adapter/merge/RootMergeStrategy.java
+++ b/geowave-raster/src/main/java/mil/nga/giat/geowave/raster/adapter/merge/RootMergeStrategy.java
@@ -18,6 +18,7 @@ import java.util.Set;
 import javax.media.jai.remote.SerializableState;
 import javax.media.jai.remote.SerializerFactory;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import mil.nga.giat.geowave.index.ByteArrayId;
 import mil.nga.giat.geowave.index.Mergeable;
 import mil.nga.giat.geowave.index.Persistable;
@@ -199,6 +200,9 @@ public class RootMergeStrategy<T extends Persistable> implements
 		}
 	}
 
+	@SuppressFBWarnings(value = {
+		"DLS_DEAD_LOCAL_STORE"
+	}, justification = "Incorrect warning, sampleModelBinary used")
 	@Override
 	public byte[] toBinary() {
 		int byteCount = 16;

--- a/geowave-raster/src/main/java/mil/nga/giat/geowave/raster/plugin/GeoWaveGTRasterFormat.java
+++ b/geowave-raster/src/main/java/mil/nga/giat/geowave/raster/plugin/GeoWaveGTRasterFormat.java
@@ -36,7 +36,7 @@ public class GeoWaveGTRasterFormat extends
 			Color.class,
 			null,
 			null);
-	public static CoordinateReferenceSystem DEFAULT_CRS;
+	public static final CoordinateReferenceSystem DEFAULT_CRS;
 	static {
 		try {
 			DEFAULT_CRS = CRS.decode("EPSG:4326");
@@ -45,6 +45,8 @@ public class GeoWaveGTRasterFormat extends
 			LOGGER.error(
 					"Unable to decode EPSG:4326 CRS",
 					e);
+			throw new RuntimeException(
+					"Unable to initialize EPSG:4326 CRS");
 		}
 	}
 

--- a/geowave-raster/src/main/java/mil/nga/giat/geowave/raster/plugin/GeoWaveRasterReader.java
+++ b/geowave-raster/src/main/java/mil/nga/giat/geowave/raster/plugin/GeoWaveRasterReader.java
@@ -103,7 +103,7 @@ public class GeoWaveRasterReader extends
 
 	private static Set<AxisDirection> LEFTDirections;
 	// class initializer
-	{
+	static {
 		LEFTDirections = new HashSet<AxisDirection>();
 		LEFTDirections.add(AxisDirection.DISPLAY_LEFT);
 		LEFTDirections.add(AxisDirection.EAST);

--- a/geowave-raster/src/main/java/mil/nga/giat/geowave/raster/stats/OverviewStatistics.java
+++ b/geowave-raster/src/main/java/mil/nga/giat/geowave/raster/stats/OverviewStatistics.java
@@ -36,22 +36,25 @@ public class OverviewStatistics extends
 
 	@Override
 	public byte[] toBinary() {
-		final List<byte[]> resolutionBinaries = new ArrayList<byte[]>(
-				resolutions.length);
-		int byteCount = 4; // an int for the list size
-		for (final Resolution res : resolutions) {
-			final byte[] resBinary = PersistenceUtils.toBinary(res);
-			resolutionBinaries.add(resBinary);
-			byteCount += (resBinary.length + 4); // an int for the binary size
-		}
+		synchronized (this) {
+			final List<byte[]> resolutionBinaries = new ArrayList<byte[]>(
+					resolutions.length);
+			int byteCount = 4; // an int for the list size
+			for (final Resolution res : resolutions) {
+				final byte[] resBinary = PersistenceUtils.toBinary(res);
+				resolutionBinaries.add(resBinary);
+				byteCount += (resBinary.length + 4); // an int for the binary
+														// size
+			}
 
-		final ByteBuffer buf = ByteBuffer.allocate(byteCount);
-		buf.putInt(resolutionBinaries.size());
-		for (final byte[] resBinary : resolutionBinaries) {
-			buf.putInt(resBinary.length);
-			buf.put(resBinary);
+			final ByteBuffer buf = ByteBuffer.allocate(byteCount);
+			buf.putInt(resolutionBinaries.size());
+			for (final byte[] resBinary : resolutionBinaries) {
+				buf.putInt(resBinary.length);
+				buf.put(resBinary);
+			}
+			return buf.array();
 		}
-		return buf.array();
 	}
 
 	@Override

--- a/geowave-services/.gitignore
+++ b/geowave-services/.gitignore
@@ -1,2 +1,1 @@
-data
 /target/

--- a/geowave-services/pom.xml
+++ b/geowave-services/pom.xml
@@ -8,7 +8,7 @@
 		<version>0.8.4-SNAPSHOT</version>
 	</parent>
 	<artifactId>geowave-services</artifactId>
-    <name>geowave-services</name>
+	<name>geowave-services</name>
 	<packaging>war</packaging>
 	<dependencies>
 		<dependency>

--- a/geowave-services/src/main/java/mil/nga/giat/geowave/services/impl/GeoserverServiceImpl.java
+++ b/geowave-services/src/main/java/mil/nga/giat/geowave/services/impl/GeoserverServiceImpl.java
@@ -868,7 +868,7 @@ public class GeoserverServiceImpl implements
 						"{'layer':{'defaultStyle':{'name':'" + defaultStyle + "'}}}",
 						MediaType.APPLICATION_JSON));
 
-		return Response.ok().build();
+		return resp;
 	}
 
 	@Override

--- a/geowave-store/pom.xml
+++ b/geowave-store/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<artifactId>geowave-parent</artifactId>

--- a/geowave-store/src/main/java/mil/nga/giat/geowave/store/CloseableIterator.java
+++ b/geowave-store/src/main/java/mil/nga/giat/geowave/store/CloseableIterator.java
@@ -3,6 +3,7 @@ package mil.nga.giat.geowave.store;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Iterator;
+import java.util.NoSuchElementException;
 
 /**
  * This interface wraps both the Iterator interface and the Closeable interface.
@@ -58,8 +59,9 @@ public interface CloseableIterator<E> extends
 		}
 
 		@Override
-		public E next() {
-			return null;
+		public E next()
+				throws NoSuchElementException {
+			throw new NoSuchElementException();
 		}
 
 		@Override

--- a/geowave-store/src/main/java/mil/nga/giat/geowave/store/data/PersistenceEncoding.java
+++ b/geowave-store/src/main/java/mil/nga/giat/geowave/store/data/PersistenceEncoding.java
@@ -94,7 +94,7 @@ public class PersistenceEncoding
 				dataPerDimension);
 	}
 
-	private class DimensionRangePair
+	private static class DimensionRangePair
 	{
 		DimensionField[] dimensions;
 		NumericData[] dataPerDimension;

--- a/geowave-store/src/main/java/mil/nga/giat/geowave/store/data/field/BasicReader.java
+++ b/geowave-store/src/main/java/mil/nga/giat/geowave/store/data/field/BasicReader.java
@@ -13,6 +13,7 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.TimeZone;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import mil.nga.giat.geowave.index.StringUtils;
 import mil.nga.giat.geowave.store.GeometryUtils;
 
@@ -55,6 +56,9 @@ public class BasicReader
 			FieldReader<Boolean>
 	{
 
+		@SuppressFBWarnings(value = {
+			"NP_BOOLEAN_RETURN_NULL"
+		}, justification = "matches pattern of other read* methods")
 		@Override
 		public Boolean readField(
 				final byte[] fieldData ) {

--- a/geowave-store/src/main/java/mil/nga/giat/geowave/store/index/CustomIdIndex.java
+++ b/geowave-store/src/main/java/mil/nga/giat/geowave/store/index/CustomIdIndex.java
@@ -60,4 +60,18 @@ public class CustomIdIndex extends
 				idBinary);
 	}
 
+	@Override
+	public boolean equals(
+			Object obj ) {
+		if (!(obj instanceof CustomIdIndex)) {
+			return false;
+		}
+		return super.equals(obj);
+	}
+
+	@Override
+	public int hashCode() {
+		return super.hashCode();
+	}
+
 }

--- a/geowave-test/pom.xml
+++ b/geowave-test/pom.xml
@@ -43,14 +43,9 @@
 		</dependency>
 		<dependency>
 			<groupId>mil.nga.giat</groupId>
-			<artifactId>geowave-analytics</artifactId>
+			<artifactId>geowave-examples</artifactId>
 			<version>${project.version}</version>
 		</dependency>
-        <dependency>
-            <groupId>mil.nga.giat</groupId>
-            <artifactId>geowave-examples</artifactId>
-            <version>${project.version}</version>
-        </dependency>
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
@@ -84,7 +79,7 @@
 	</dependencies>
 	<build>
 		<plugins>
-         	<plugin>
+			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-dependency-plugin</artifactId>
 				<version>2.9</version>
@@ -185,7 +180,7 @@
 								<instance>${instance}</instance>
 								<username>${username}</username>
 								<password>${password}</password>
-                                <geoserver.version>${geoserver.version}</geoserver.version>
+								<geoserver.version>${geoserver.version}</geoserver.version>
 							</systemPropertyVariables>
 							<!-- Sonar currently just supports surefire so "trick" Sonar into 
 								thinking they are surefire reports -->

--- a/geowave-test/src/main/java/mil/nga/giat/geowave/test/GeoWaveTestEnvironment.java
+++ b/geowave-test/src/main/java/mil/nga/giat/geowave/test/GeoWaveTestEnvironment.java
@@ -15,9 +15,11 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TimeZone;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import mil.nga.giat.geowave.accumulo.AccumuloOperations;
 import mil.nga.giat.geowave.accumulo.BasicAccumuloOperations;
 import mil.nga.giat.geowave.ingest.IngestMain;
@@ -75,7 +77,8 @@ abstract public class GeoWaveTestEnvironment
 			"./target/accumulo_temp"); // breaks on windows if temp directory
 										// isn't on same drive as project
 
-	protected static boolean DEFER_CLEANUP = false;
+	protected static final AtomicBoolean DEFER_CLEANUP = new AtomicBoolean(
+			false);
 
 	protected static boolean isYarn() {
 		return VersionUtil.compareVersions(
@@ -205,10 +208,13 @@ abstract public class GeoWaveTestEnvironment
 		return (str != null) && !str.isEmpty();
 	}
 
+	@SuppressFBWarnings(value = {
+		"SWL_SLEEP_WITH_LOCK_HELD"
+	}, justification = "Sleep in lock while waiting for external resources")
 	@AfterClass
 	public static void cleanup() {
 		synchronized (MUTEX) {
-			if (!DEFER_CLEANUP) {
+			if (!DEFER_CLEANUP.get()) {
 
 				if (accumuloOperations == null) {
 					Assert.fail("Invalid state <null> for accumulo operations during CLEANUP phase");
@@ -284,6 +290,9 @@ abstract public class GeoWaveTestEnvironment
 		public Set<Long> hashedCentroids;
 		public int count;
 
+		@SuppressFBWarnings({
+			"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"
+		})
 		protected ExpectedResults(
 				final Set<Long> hashedCentroids,
 				final int count ) {

--- a/geowave-test/src/test/java/mil/nga/giat/geowave/test/GeoWaveBasicIT.java
+++ b/geowave-test/src/test/java/mil/nga/giat/geowave/test/GeoWaveBasicIT.java
@@ -264,7 +264,8 @@ public class GeoWaveBasicIT extends
 	public void testStats(
 			final File[] inputFiles,
 			final Index index ) {
-		final LocalFileIngestPlugin<SimpleFeature> localFileIngest = new GeoToolsVectorDataStoreIngestPlugin(Filter.INCLUDE);
+		final LocalFileIngestPlugin<SimpleFeature> localFileIngest = new GeoToolsVectorDataStoreIngestPlugin(
+				Filter.INCLUDE);
 		final Map<ByteArrayId, StatisticsCache> statsCache = new HashMap<ByteArrayId, StatisticsCache>();
 		for (final File inputFile : inputFiles) {
 			LOGGER.warn("Calculating stats from file '" + inputFile.getName() + "' - this may take several minutes...");

--- a/geowave-test/src/test/java/mil/nga/giat/geowave/test/GeoWaveITSuite.java
+++ b/geowave-test/src/test/java/mil/nga/giat/geowave/test/GeoWaveITSuite.java
@@ -32,14 +32,14 @@ public class GeoWaveITSuite
 	@BeforeClass
 	public static void setup() {
 		synchronized (GeoWaveTestEnvironment.MUTEX) {
-			GeoWaveTestEnvironment.DEFER_CLEANUP = true;
+			GeoWaveTestEnvironment.DEFER_CLEANUP.set(true);
 		}
 	}
 
 	@AfterClass
 	public static void cleanup() {
 		synchronized (GeoWaveTestEnvironment.MUTEX) {
-			GeoWaveTestEnvironment.DEFER_CLEANUP = false;
+			GeoWaveTestEnvironment.DEFER_CLEANUP.set(false);
 			ServicesTestEnvironment.stopServices();
 			GeoWaveTestEnvironment.cleanup();
 		}

--- a/geowave-types/pom.xml
+++ b/geowave-types/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>mil.nga.giat</groupId>

--- a/geowave-types/src/main/java/mil/nga/giat/geowave/types/geotools/raster/GeoToolsRasterDataStoreIngestType.java
+++ b/geowave-types/src/main/java/mil/nga/giat/geowave/types/geotools/raster/GeoToolsRasterDataStoreIngestType.java
@@ -14,7 +14,7 @@ import org.opengis.coverage.grid.GridCoverage;
  * local file system into GeoWave.
  */
 public class GeoToolsRasterDataStoreIngestType implements
-IngestTypePluginProviderSpi<Object, GridCoverage>
+		IngestTypePluginProviderSpi<Object, GridCoverage>
 {
 
 	@Override

--- a/geowave-types/src/main/java/mil/nga/giat/geowave/types/geotools/vector/SimpleFeatureGeoWaveWrapper.java
+++ b/geowave-types/src/main/java/mil/nga/giat/geowave/types/geotools/vector/SimpleFeatureGeoWaveWrapper.java
@@ -32,12 +32,12 @@ import org.opengis.filter.identity.FeatureId;
  * closeable iterator of GeoWaveData
  */
 public class SimpleFeatureGeoWaveWrapper implements
-CloseableIterator<GeoWaveData<SimpleFeature>>
+		CloseableIterator<GeoWaveData<SimpleFeature>>
 {
 	private final static Logger LOGGER = Logger.getLogger(SimpleFeatureGeoWaveWrapper.class);
 
 	private class InternalIterator implements
-	CloseableIterator<GeoWaveData<SimpleFeature>>
+			CloseableIterator<GeoWaveData<SimpleFeature>>
 	{
 		private final SimpleFeatureIterator featureIterator;
 		private final WritableDataAdapter<SimpleFeature> dataAdapter;
@@ -98,7 +98,7 @@ CloseableIterator<GeoWaveData<SimpleFeature>>
 
 		private SimpleFeature retype(
 				final SimpleFeature original )
-						throws IllegalAttributeException {
+				throws IllegalAttributeException {
 			final SimpleFeatureType target = builder.getFeatureType();
 			for (int i = 0; i < target.getAttributeCount(); i++) {
 				final AttributeDescriptor attributeType = target.getDescriptor(i);

--- a/geowave-types/src/main/java/mil/nga/giat/geowave/types/gpx/GPXConsumer.java
+++ b/geowave-types/src/main/java/mil/nga/giat/geowave/types/gpx/GPXConsumer.java
@@ -92,7 +92,6 @@ public class GPXConsumer implements
 
 	XMLEventReader eventReader;
 	GeoWaveData<SimpleFeature> nextFeature = null;
-	Coordinate nextCoordinate = null;
 
 	/**
 	 * 
@@ -597,8 +596,7 @@ public class GPXConsumer implements
 							minTime);
 				}
 			}
-			return (minTime < Long.MAX_VALUE) ? new Long(
-					minTime) : null;
+			return (minTime < Long.MAX_VALUE) ? Long.valueOf(minTime) : null;
 		}
 
 		private Long getEndTime() {
@@ -614,8 +612,7 @@ public class GPXConsumer implements
 							maxTime);
 				}
 			}
-			return (maxTime > 0) ? new Long(
-					maxTime) : null;
+			return (maxTime > 0) ? Long.valueOf(maxTime) : null;
 		}
 
 		public boolean build(
@@ -746,8 +743,7 @@ public class GPXConsumer implements
 				setAttribute(
 						builder,
 						"NumberPoints",
-						new Long(
-								childSequence.size()));
+						Long.valueOf(childSequence.size()));
 
 				final Long minTime = getStartTime();
 				if (minTime != null) {

--- a/geowave-types/src/main/java/mil/nga/giat/geowave/types/gpx/GpxIngestPlugin.java
+++ b/geowave-types/src/main/java/mil/nga/giat/geowave/types/gpx/GpxIngestPlugin.java
@@ -12,6 +12,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
 import javax.xml.stream.XMLStreamException;
 
@@ -56,11 +57,12 @@ public class GpxIngestPlugin extends
 	private final static String TAG_SEPARATOR = " ||| ";
 
 	private Map<Long, GpxTrack> metadata = null;
-	private static long currentFreeTrackId = 0;
+	private static final AtomicLong currentFreeTrackId = new AtomicLong(
+			0);
 
 	private final Index[] supportedIndices;
 
-	public GpxIngestPlugin( ) {
+	public GpxIngestPlugin() {
 		supportedIndices = new Index[] {
 			IndexType.SPATIAL_VECTOR.createDefaultIndex(),
 			IndexType.SPATIAL_TEMPORAL_VECTOR.createDefaultIndex()
@@ -176,7 +178,7 @@ public class GpxIngestPlugin extends
 		}
 		if (track == null) {
 			track = new GpxTrack();
-			track.setTrackid(currentFreeTrackId++);
+			track.setTrackid(currentFreeTrackId.getAndIncrement());
 		}
 
 		try {

--- a/geowave-types/src/main/java/mil/nga/giat/geowave/types/gpx/GpxUtils.java
+++ b/geowave-types/src/main/java/mil/nga/giat/geowave/types/gpx/GpxUtils.java
@@ -30,6 +30,7 @@ import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
 import javax.xml.validation.Validator;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.log4j.Logger;
 import org.geotools.feature.AttributeTypeBuilder;
 import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
@@ -88,6 +89,9 @@ public class GpxUtils
 				source);
 	}
 
+	@SuppressFBWarnings({
+		"SF_SWITCH_NO_DEFAULT"
+	})
 	public static Map<Long, GpxTrack> parseOsmMetadata(
 			final File metadataFile )
 			throws FileNotFoundException,

--- a/geowave-utils/.gitignore
+++ b/geowave-utils/.gitignore
@@ -1,2 +1,1 @@
-data
 /target/

--- a/geowave-vector/src/main/java/mil/nga/giat/geowave/vector/adapter/FeatureDataAdapter.java
+++ b/geowave-vector/src/main/java/mil/nga/giat/geowave/vector/adapter/FeatureDataAdapter.java
@@ -563,7 +563,7 @@ public class FeatureDataAdapter extends
 				this.reprojectedType);
 	}
 
-	private class FeatureWritableSerializer implements
+	private static class FeatureWritableSerializer implements
 			HadoopWritableSerializer<SimpleFeature, FeatureWritable>
 	{
 

--- a/geowave-vector/src/main/java/mil/nga/giat/geowave/vector/auth/EmptyAuthorizationProvider.java
+++ b/geowave-vector/src/main/java/mil/nga/giat/geowave/vector/auth/EmptyAuthorizationProvider.java
@@ -18,7 +18,6 @@ public class EmptyAuthorizationProvider implements
 
 	@Override
 	public String[] getAuthorizations() {
-		Authentication auth = SecurityContextHolder.getContext().getAuthentication();
 		return new String[0];
 	}
 

--- a/geowave-vector/src/main/java/mil/nga/giat/geowave/vector/plugin/GeoWaveGTDataStore.java
+++ b/geowave-vector/src/main/java/mil/nga/giat/geowave/vector/plugin/GeoWaveGTDataStore.java
@@ -101,7 +101,7 @@ public class GeoWaveGTDataStore extends
 {
 	/** Package logger */
 	private final static Logger LOGGER = Logger.getLogger(GeoWaveGTDataStore.class);
-	public static CoordinateReferenceSystem DEFAULT_CRS;
+	public static final CoordinateReferenceSystem DEFAULT_CRS;
 	static {
 		try {
 			DEFAULT_CRS = CRS.decode(
@@ -111,6 +111,9 @@ public class GeoWaveGTDataStore extends
 		catch (final FactoryException e) {
 			LOGGER.error(
 					"Unable to decode EPSG:4326 CRS",
+					e);
+			throw new RuntimeException(
+					"Unable to initialize EPSG:4326 object",
 					e);
 		}
 	}

--- a/geowave-vector/src/main/java/mil/nga/giat/geowave/vector/plugin/lock/AuthorizedLock.java
+++ b/geowave-vector/src/main/java/mil/nga/giat/geowave/vector/plugin/lock/AuthorizedLock.java
@@ -5,6 +5,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.geotools.data.Transaction;
 import org.geotools.data.Transaction.State;
 
@@ -18,6 +19,9 @@ import org.geotools.data.Transaction.State;
  * 
  * 
  */
+@SuppressFBWarnings({
+	"SE_TRANSIENT_FIELD_NOT_RESTORED"
+})
 public class AuthorizedLock implements
 		State,
 		java.io.Serializable

--- a/geowave-vector/src/main/java/mil/nga/giat/geowave/vector/plugin/lock/MemoryLockManager.java
+++ b/geowave-vector/src/main/java/mil/nga/giat/geowave/vector/plugin/lock/MemoryLockManager.java
@@ -6,6 +6,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.log4j.Logger;
 
 import mil.nga.giat.geowave.vector.plugin.GeoWavePluginConfig;
@@ -90,6 +91,9 @@ public class MemoryLockManager extends
 			lockToRelease.resetExpireTime();
 	}
 
+	@SuppressFBWarnings(value = {
+		"MWN_MISMATCHED_WAIT"
+	}, justification = "incorrect flag; lock held (in synchronized block)")
 	@Override
 	public void lock(
 			AuthorizedLock lock,

--- a/geowave-vector/src/main/java/mil/nga/giat/geowave/vector/query/row/BasicRowIdStore.java
+++ b/geowave-vector/src/main/java/mil/nga/giat/geowave/vector/query/row/BasicRowIdStore.java
@@ -130,7 +130,7 @@ public class BasicRowIdStore
 			final MathTransform worldToData )
 			throws NoninvertibleTransformException,
 			MismatchedDimensionException {
-		Key minRowId = null;
+
 		// add one to the pixel in height because pixel space starts at
 		// the top and goes down so to get the lower left spatial
 		// coordinate for a pixel you want the [x, y+1] in pixel space
@@ -167,11 +167,9 @@ public class BasicRowIdStore
 			final Key rowIdKey = new Key(
 					new Text(
 							rowId.getBytes()));
-			if (minRowId == null || (minRowId.compareTo(rowIdKey) > 0)) {
-				minRowId = rowIdKey;
-			}
+			return rowIdKey;
 		}
-		return minRowId;
+		return null;
 	}
 
 	protected int getPixelIndex(

--- a/geowave-vector/src/main/java/mil/nga/giat/geowave/vector/query/row/DecomposedQueryRangeRowProvider.java
+++ b/geowave-vector/src/main/java/mil/nga/giat/geowave/vector/query/row/DecomposedQueryRangeRowProvider.java
@@ -4,6 +4,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.TreeSet;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import mil.nga.giat.geowave.accumulo.util.AccumuloUtils;
 import mil.nga.giat.geowave.index.ByteArrayRange;
 import mil.nga.giat.geowave.index.NumericIndexStrategy;
@@ -26,6 +27,9 @@ public class DecomposedQueryRangeRowProvider extends
 {
 	private final TreeSet<Range> ranges;
 
+	@SuppressFBWarnings(value = {
+		"RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE"
+	}, justification = "newer constraint types may be null")
 	public DecomposedQueryRangeRowProvider(
 			final NumericIndexStrategy indexStrategy,
 			final Envelope envelope ) {

--- a/geowave-vector/src/main/java/mil/nga/giat/geowave/vector/util/FeatureCollectionRedistributor.java
+++ b/geowave-vector/src/main/java/mil/nga/giat/geowave/vector/util/FeatureCollectionRedistributor.java
@@ -486,7 +486,7 @@ public class FeatureCollectionRedistributor
 		featureCollectionWriter.close();
 	}
 
-	private class RawFeatureCollectionDataAdapter extends
+	private static class RawFeatureCollectionDataAdapter extends
 			FeatureCollectionDataAdapter
 	{
 		public RawFeatureCollectionDataAdapter(

--- a/geowave-vector/src/main/java/mil/nga/giat/geowave/vector/wms/DelayedBackbufferGraphic.java
+++ b/geowave-vector/src/main/java/mil/nga/giat/geowave/vector/wms/DelayedBackbufferGraphic.java
@@ -16,6 +16,8 @@
  */
 package mil.nga.giat.geowave.vector.wms;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import java.awt.Color;
 import java.awt.Composite;
 import java.awt.Font;
@@ -681,6 +683,10 @@ public final class DelayedBackbufferGraphic extends
 				arcHeight);
 	}
 
+	@SuppressFBWarnings(value = {
+		"FI_PUBLIC_SHOULD_BE_PROTECTED",
+		"FI_EXPLICIT_INVOCATION"
+	}, justification = "Access defined in java.awt.Graphics; finalization only called by container resource finalize method)_")
 	@Override
 	public void finalize() {
 		super.finalize();

--- a/geowave-vector/src/main/java/mil/nga/giat/geowave/vector/wms/accumulo/ServerRenderOptions.java
+++ b/geowave-vector/src/main/java/mil/nga/giat/geowave/vector/wms/accumulo/ServerRenderOptions.java
@@ -18,6 +18,7 @@ import javax.media.jai.remote.SerializableState;
 import javax.media.jai.remote.Serializer;
 import javax.media.jai.remote.SerializerFactory;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import mil.nga.giat.geowave.index.Persistable;
 import mil.nga.giat.geowave.vector.wms.DelayedBackbufferGraphic;
 
@@ -183,6 +184,9 @@ public class ServerRenderOptions implements
 		return buf.array();
 	}
 
+	@SuppressFBWarnings(value = {
+		"JLM_JSR166_UTILCONCURRENT_MONITORENTER"
+	}, justification = "lock ensures transactional atomicity")
 	private void registerSerializers() {
 		synchronized (serializerRegistered) {
 			if (!serializerRegistered.get()) {

--- a/packaging/rpm/centos/6/SOURCES/default.xml
+++ b/packaging/rpm/centos/6/SOURCES/default.xml
@@ -1,4 +1,4 @@
 <workspace>
-    <id>WorkspaceInfoImpl--5ccd188:124761b8d78:-9dd9</id>
-    <name>geowave</name>
+	<id>WorkspaceInfoImpl--5ccd188:124761b8d78:-9dd9</id>
+	<name>geowave</name>
 </workspace>

--- a/packaging/rpm/centos/6/SOURCES/namespace.xml
+++ b/packaging/rpm/centos/6/SOURCES/namespace.xml
@@ -1,5 +1,5 @@
 <namespace>
-    <id>NamespaceInfoImpl--5ccd188:124761b8d78:-9dd8</id>
-    <prefix>geowave</prefix>
-    <uri>https://github.com/ngageoint/geowave</uri>
+	<id>NamespaceInfoImpl--5ccd188:124761b8d78:-9dd8</id>
+	<prefix>geowave</prefix>
+	<uri>https://github.com/ngageoint/geowave</uri>
 </namespace>

--- a/packaging/rpm/centos/6/SOURCES/workspace.xml
+++ b/packaging/rpm/centos/6/SOURCES/workspace.xml
@@ -1,4 +1,4 @@
 <workspace>
-    <id>WorkspaceInfoImpl--5ccd188:124761b8d78:-9dd9</id>
-    <name>geowave</name>
+	<id>WorkspaceInfoImpl--5ccd188:124761b8d78:-9dd9</id>
+	<name>geowave</name>
 </workspace>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,11 @@
 		<sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
 		<test.args>-Xms256m -Xmx1024m -XX:MaxPermSize=256m</test.args>
 		<formatter.location>${project.basedir}/../tools/eclipse/eclipse-formatter.xml</formatter.location>
-		<findbugs.version>3.0.0</findbugs.version>
+		<findbugs.version>3.0.1</findbugs.version>
+		<findbugs.omitVisitors>MutableStaticFields,FindReturnRef</findbugs.omitVisitors>
+		<findbugs.effort>Max</findbugs.effort>
+		<findbugs.threshold>Medium</findbugs.threshold>
+		<findbugs.failOnError>true</findbugs.failOnError>
 	</properties>
 	<dependencyManagement>
 		<dependencies>
@@ -221,7 +225,7 @@
 			<dependency>
 				<groupId>com.google.code.findbugs</groupId>
 				<artifactId>annotations</artifactId>
-				<version>${findbugs.version}</version>
+				<version>3.0.0</version>
 				<scope>compile</scope>
 			</dependency>
 		</dependencies>
@@ -253,6 +257,44 @@
 									</pluginExecutionFilter>
 									<action>
 										<ignore />
+									</action>
+								</pluginExecution>
+								<pluginExecution>
+									<pluginExecutionFilter>
+										<groupId>
+											com.googlecode.maven-java-formatter-plugin
+										</groupId>
+										<artifactId>
+											maven-java-formatter-plugin
+										</artifactId>
+										<versionRange>
+											[0.4,)
+										</versionRange>
+										<goals>
+											<goal>format</goal>
+										</goals>
+									</pluginExecutionFilter>
+									<action>
+										<ignore></ignore>
+									</action>
+								</pluginExecution>
+								<pluginExecution>
+									<pluginExecutionFilter>
+										<groupId>
+											org.sonatype.plugins
+										</groupId>
+										<artifactId>
+											munge-maven-plugin
+										</artifactId>
+										<versionRange>
+											[1.0,)
+										</versionRange>
+										<goals>
+											<goal>munge</goal>
+										</goals>
+									</pluginExecutionFilter>
+									<action>
+										<ignore></ignore>
 									</action>
 								</pluginExecution>
 							</pluginExecutions>
@@ -390,9 +432,6 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
 				<version>2.9.1</version>
-				<configuration>
-					<additionalparam>-Xdoclint:none</additionalparam>
-				</configuration>
 				<executions>
 					<execution>
 						<id>aggregate</id>
@@ -404,6 +443,7 @@
 							<sourceFileIncludes>
 								<include>**.java</include>
 							</sourceFileIncludes>
+							<additionalparam>${javadoc.opts}</additionalparam>
 							<quiet>true</quiet>
 							<windowtitle>GeoWave ${project.version}</windowtitle>
 							<doctitle>GeoWave ${project.version}</doctitle>
@@ -474,12 +514,11 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>findbugs-maven-plugin</artifactId>
-				<version>${findbugs.version}</version>
 				<configuration>
-					<failOnError>false</failOnError>
-					<threshold>Medium</threshold>
-					<effort>Max</effort>
-					<xmlOutput>true</xmlOutput>
+					<failOnError>${findbugs.failOnError}</failOnError>
+					<threshold>${findbugs.threshold}</threshold>
+					<effort>${findbugs.effort}</effort>
+					<excludeFilterFile>${findbugs.filterFile}</excludeFilterFile>
 				</configuration>
 				<executions>
 					<execution>
@@ -533,10 +572,11 @@
 				<configuration>
 					<findbugsXmlOutput>true</findbugsXmlOutput>
 					<xmlOutput>true</xmlOutput>
-					<effort>Max</effort>
-					<threshold>Low</threshold>
-					<failOnError>false</failOnError>
+					<effort>${findbugs.effort}</effort>
+					<threshold>${findbugs.threshold}</threshold>
+					<failOnError>${findbugs.failOnError}</failOnError>
 					<xmlOutputDirectory>${project.basedir}/target/site</xmlOutputDirectory>
+					<omitVisitors>${findbugs.omitVisitors}</omitVisitors>
 				</configuration>
 			</plugin>
 		</plugins>
@@ -692,6 +732,15 @@
 					<layout>default</layout>
 				</repository>
 			</repositories>
+		</profile>
+		<profile>
+			<id>doclint-java8-disable</id>
+			<activation>
+				<jdk>[1.8,)</jdk>
+			</activation>
+			<properties>
+				<javadoc.opts>-Xdoclint:none</javadoc.opts>
+			</properties>
 		</profile>
 	</profiles>
 </project>


### PR DESCRIPTION
#228 
Also added findbugs to the build now;  had to exempt a few visitors  (see the omitVisitors property) - all of them basically caused by 
  * returning array types (byte[] value)
  * static non private instances of array types (or other objects)

it's that mutable state / security warning we talked about.  There's ~90 of those across the whole project that are not tracked.  Not necessarily issues, but probably need to take the time to verify before we annotate them directly.

But for any of the other errors findbugs will now fail the build.   The error will be printed in the mvn output, but the easiest way is either to get a findbugs plugin in your ide, or if you type

```
mvn findbugs:gui
```

a window detailing and explaining the issues will pop up for each module build

---------------------

also hits an admittedly unrelated javadoc issue - the -Xdoclint:none command needed to make java8 not blow up causes java7 to blow up.  This was preventing the install phase from finishing, which caused the verify phase to pull old libraries from the cache, which led to random results - so resolved it here (with a profile that injects the argument and only activates for java8+)