### PR TITLE
Added deploy to S3 option+repo

### DIFF
--- a/geowave-analytics/src/main/java/mil/nga/giat/geowave/analytics/clustering/CentroidManagerGeoWave.java
+++ b/geowave-analytics/src/main/java/mil/nga/giat/geowave/analytics/clustering/CentroidManagerGeoWave.java
@@ -252,7 +252,8 @@ public class CentroidManagerGeoWave<T> implements
 			LOGGER.error("Cannot instantiate " + GeoWaveConfiguratorBase.enumToConfKey(
 					this.getClass(),
 					CommonParameters.Common.ACCUMULO_CONNECT_FACTORY));
-			throw new IOException(e.getLocalizedMessage(),
+			throw new IOException(
+					e.getLocalizedMessage(),
 					e);
 		}
 		dataStore = new AccumuloDataStore(
@@ -279,7 +280,8 @@ public class CentroidManagerGeoWave<T> implements
 					SimpleFeatureItemWrapperFactory.class);
 		}
 		catch (InstantiationException e) {
-			throw new IOException(e.getLocalizedMessage(),
+			throw new IOException(
+					e.getLocalizedMessage(),
 					e);
 		}
 		this.centroidDataTypeId = runTimeProperties.getPropertyAsString(CentroidParameters.Centroid.DATA_TYPE_ID);
@@ -305,7 +307,8 @@ public class CentroidManagerGeoWave<T> implements
 		}
 		catch (InstantiationException | IllegalAccessException e) {
 			throw new IOException(
-					e.getLocalizedMessage(),e);
+					e.getLocalizedMessage(),
+					e);
 		}
 
 		dataStore = new AccumuloDataStore(

--- a/geowave-vector/src/main/java/mil/nga/giat/geowave/vector/adapter/FeatureCollectionDataAdapter.java
+++ b/geowave-vector/src/main/java/mil/nga/giat/geowave/vector/adapter/FeatureCollectionDataAdapter.java
@@ -85,7 +85,7 @@ import org.opengis.referencing.operation.MathTransform;
  * the term 'start' and the other contains either the term 'stop' or 'end' it
  * will interpret the combination of these attributes as a time range to index
  * on.
- *
+ * 
  */
 public class FeatureCollectionDataAdapter extends
 		AbstractDataAdapter<DefaultFeatureCollection> implements

--- a/geowave-vector/src/main/java/mil/nga/giat/geowave/vector/adapter/FeatureDataAdapter.java
+++ b/geowave-vector/src/main/java/mil/nga/giat/geowave/vector/adapter/FeatureDataAdapter.java
@@ -47,7 +47,7 @@ import org.opengis.referencing.operation.MathTransform;
  * This data adapter will handle all reading/writing concerns for storing and
  * retrieving GeoTools SimpleFeature objects to and from a GeoWave persistent
  * store in Accumulo.
- *
+ * 
  * If the implementor needs to write rows with particular visibility, this can
  * be done by providing a FieldVisibilityHandler to a constructor or a
  * VisibilityManagement to a constructor. When using VisibilityManagement, the
@@ -57,26 +57,26 @@ import org.opengis.referencing.operation.MathTransform;
  * attribute that contains the visibility meta-data.
  * persistedType.getDescriptor("someAttributeName").getUserData().put(
  * "visibility", Boolean.TRUE)
- *
- *
+ * 
+ * 
  * The adapter will use the SimpleFeature's default geometry for spatial
  * indexing.
- *
+ * 
  * The adaptor will use the first temporal attribute (a Calendar or Date object)
  * as the timestamp of a temporal index.
- *
+ * 
  * If the feature type contains a UserData property 'time' for a specific time
  * attribute with Boolean.TRUE, then the attribute is used as the timestamp of a
  * temporal index.
- *
+ * 
  * If the feature type contains UserData properties 'start' and 'end' for two
  * different time attributes with value Boolean.TRUE, then the attributes are
  * used for a range index.
- *
+ * 
  * If the feature type contains a UserData property 'time' for *all* time
  * attributes with Boolean.FALSE, then a temporal index is not used.
- *
- *
+ * 
+ * 
  */
 @SuppressWarnings("unchecked")
 public class FeatureDataAdapter extends

--- a/geowave-vector/src/test/java/mil/nga/giat/geowave/vector/utils/QueryIndexHelperTest.java
+++ b/geowave-vector/src/test/java/mil/nga/giat/geowave/vector/utils/QueryIndexHelperTest.java
@@ -555,7 +555,7 @@ public class QueryIndexHelperTest
 
 		Coordinate coord = ((Point) defaultCRSFeat.getDefaultGeometry()).getCoordinate();
 
-	    // coordinate should match reprojected feature
+		// coordinate should match reprojected feature
 		assertEquals(
 				coord.x,
 				geoStats.getMinX(),

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,18 @@
 			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
 		</license>
 	</licenses>
+	<distributionManagement>
+		<repository>
+			<id>geowave-maven-releases</id>
+			<name>GeoWave AWS Release Repository</name>
+			<url>s3://geowave-maven/release</url>
+		</repository>
+		<snapshotRepository>
+			<id>geowave-maven-snapshots</id>
+			<name>GeoWave AWS Snapshot Repository</name>
+			<url>s3://geowave-maven/snapshot</url>
+		</snapshotRepository>
+	</distributionManagement>
 	<scm>
 		<url>https://github.com/ngageoint/geowave.git</url>
 		<connection>scm:git:git@github.com:ngageoint/geowave.git</connection>
@@ -231,6 +243,13 @@
 		</dependencies>
 	</dependencyManagement>
 	<build>
+		<extensions>
+			<extension>
+				<groupId>org.springframework.build</groupId>
+				<artifactId>aws-maven</artifactId>
+				<version>5.0.0.RELEASE</version>
+			</extension>
+		</extensions>
 		<pluginManagement>
 			<plugins>
 				<!--This plugin's configuration is used to store Eclipse m2e settings 


### PR DESCRIPTION
Other files are formatting auto-changes; only real change here is to the pom.xml

Added the following S3 based maven repos for geowave:
```
	<distributionManagement>
		<repository>
			<id>geowave-maven-releases</id>
			<name>GeoWave AWS Release Repository</name>
			<url>s3://geowave-maven/release</url>
		</repository>
		<snapshotRepository>
			<id>geowave-maven-snapshots</id>
			<name>GeoWave AWS Snapshot Repository</name>
			<url>s3://geowave-release/snapshot</url>
		</snapshotRepository>
	</distributionManagement>
```

mvn deploy will now push to releases or snapshots (based on if ${project.version} contains "SNAPSHOT" in the string).

The repo is publicly viewable, but in order to publish you need the access keys - you can put them in your ~/.m2/settings.xml - here is the skeleton fragment:

```
  <servers>
    <server>
      <id>geowave-maven-releases</id>
      <username>ACCESS_KEY_ID</username>
      <password>SECRET_ACCESS_KEY</password>
    </server>
    <server>
      <id>geowave-maven-snapshots</id>
      <username>ACCESS_KEY_ID</username>
      <password>SECRET_ACCESS_KEY</password>
    </server>
  </servers>
```

