### PR TITLE
Download page and documentation updates

### DIFF
--- a/.utility/changelog-generator.sh
+++ b/.utility/changelog-generator.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ "$TRAVIS_REPO_SLUG" == "ngageoint/geowave" ] && [ "$TRAVIS_JDK_VERSION" == "oraclejdk7" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" == "master" ]
+if [ "$TRAVIS_REPO_SLUG" == "ngageoint/geowave" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" == "master" ]
 then
   gem install github_changelog_generator
   github_changelog_generator

--- a/.utility/push-javadoc-to-gh-pages.sh
+++ b/.utility/push-javadoc-to-gh-pages.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ "$TRAVIS_REPO_SLUG" == "ngageoint/geowave" ] && [ "$TRAVIS_JDK_VERSION" == "oraclejdk7" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" == "master" ]; then
+if [ "$TRAVIS_REPO_SLUG" == "ngageoint/geowave" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" == "master" ]; then
 
   echo -e "Publishing site ...\n"
 

--- a/README.md
+++ b/README.md
@@ -23,14 +23,14 @@ Basically, GeoWave is working to bridge geospatial software with distributed com
 * A [changelog is available](http://ngageoint.github.io/geowave/changelog.html) which details the changes and features for each of our [github releases](https://github.com/ngageoint/geowave/releases)
 
 ## The Software
-* We have a [RPM repository](http://s3.amazonaws.com/geowave-rpms/index.html)
+* We have a [RPM repository](http://ngageoint.github.io/geowave/packages.html)
   * See [Documentation: Installation from RPM](http://ngageoint.github.io/geowave/documentation.html#installation-from-rpm) for more info.
   * Deb packages if enough people request them
 * We have [Maven artifact repositories](http://ngageoint.github.io/geowave/documentation.html#maven-repositories) (indexes not enabled, but it works in a maven repo fragment)
   * Releases: http://geowave-maven.s3-website-us-east-1.amazonaws.com/release
   * Snapshots: http://geowave-maven.s3-website-us-east-1.amazonaws.com/snapshot (nightly)
 * We have a [vagrant dev environment](https://github.com/ngageoint/geowave/tree/master/vagrant)
-* We have a development all in one RPM package: "geowave-repo-dev"
+* We have a development all in one RPM package: "geowave-cdh5-single-host"
 * And you can always [build from source](http://ngageoint.github.io/geowave/documentation.html#installation-from-source)
   
  

--- a/docs/content/050-framework.adoc
+++ b/docs/content/050-framework.adoc
@@ -71,9 +71,6 @@ http://www.naturalearthdata.com/downloads/50m-cultural-vectors/[50m Cultural Vec
 Let's download the Admin 0 - Countries shapefile:
 http://naciscdn.org/naturalearth/50m/cultural/ne_50m_admin_0_countries.zip[ne_50m_admin_0_countries.zip]
 
-Okay, let's ingest this. I'll take some liberty with the file locations,
-but the process should be obvious
-
 [source, bash]
 ----
 $ mkdir ingest
@@ -82,5 +79,16 @@ $ cd ingest
 $ unzip ne_50m_admin_0_countries.zip
 $ rm ne_50m_admin_0_countries.zip
 $ cd ..
-$ geowave-ingest -localingest -b ./ingest -i ACCUMULO_INSTANCE_NAME -n geowave.50m_admin_0_countries -t geotools-vector -u USERNAME -p PASSWORD -z zoo-1:2181
+$ geowave-ingest -localingest \
+      -b ./ingest \
+      -i ACCUMULO_INSTANCE_NAME \
+      -n geowave.50m_admin_0_countries \ <1>
+      -t geotools-vector \ <2>
+      -u USERNAME \
+      -p PASSWORD \
+      -z ZOOKEEPER_HOST_NAME:2181
 ----
+<1> We preface the table name with the Accumulo namespace we configured earlier in the Accumulo configuration section followed by a dot (NAMESPACE.TABLE_NAME)
+<2> Ensure you match the correct GeoWave ingest plugin type for the data you are ingesting
+
+After running the ingest command you should see the various index tables in Accumulo

--- a/docs/content/075-install-from-rpm.adoc
+++ b/docs/content/075-install-from-rpm.adoc
@@ -4,17 +4,18 @@
 
 === Overview
 
-There is a public http://s3.amazonaws.com/geowave-rpms/index.html[GeoWave RPM Repo] available with the following packages.
+There is a public http://ngageoint.github.io/geowave/packages.html[GeoWave RPM Repo] available with the following packages.
 As you'll need to coordinate a restart of Accumulo to pick up changes to the GeoWave iterator classes the repos default to
 be disabled so you can keep auto updates enabled. When ready to do an update simply add `--enablerepo=geowave` to your
-command.
+command. The packages are built for a number of different hadoop distributions (Cloudera, Hortonworks and Apache) the RPMs
+have the vendor name embedded as the second portion of the rpm name (geowave-apache-accumulo, geowave-hdp2-accumulo or geowave-cdh5-accumulo)
 
 === Examples
 
 [source, bash]
 ----
 # Use GeoWave repo RPM to configure a host and search for GeoWave RPMs to install
-rpm -Uvh http://s3.amazonaws.com/geowave-rpms/release/noarch/geowave-repo-dev-1.0-3.noarch.rpm
+rpm -Uvh http://s3.amazonaws.com/geowave-rpms/release/noarch/geowave-repo-1.0-3.noarch.rpm
 yum --enablerepo=geowave search geowave
 
 # Install GeoWave Accumulo iterator on a host (probably a namenode)
@@ -31,26 +32,26 @@ Restart Accumulo service
 |Name
 |Description
 
-|geowave-cdh5-accumulo
+|geowave-*-accumulo
 |Accumulo Components
 
-|geowave-cdh5-core
+|geowave-*-core
 |Core (home directory and geowave user)
 
-|geowave-cdh5-docs
+|geowave-*-docs
 |Documentation (HTML, PDF and man pages)
 
-|geowave-cdh5-ingest
+|geowave-*-ingest
 |Ingest Tool
 
-|geowave-cdh5-jetty
-|GeoServer Components
+|geowave-*-jetty
+|GeoServer components installed into /usr/local/geowave/geoserver and available at http://FQDN:8080/geoserver
 
-|geowave-cdh5-puppet
+|geowave-*-puppet
 |Puppet Scripts
 
-|geowave-cdh5-single-host
-|All GeoWave Components
+|geowave-*-single-host
+|All GeoWave Components installed on a single host (sometimes useful for development)
 
 |geowave-repo
 |GeoWave RPM Repo config file
@@ -59,3 +60,12 @@ Restart Accumulo service
 |GeoWave Development RPM Repo config file
 
 |===
+
+
+=== RPM Installation Notes
+
+* geowwave-cdh5-accumulo: This RPM will install the GeoWave Accumulo iterator into the local file system and then upload
+it into HDFS using the `hadoop fs -put` command. This means of deployment requires that the RPM is installed on a node that
+has the correct binaries and configuration in place to push files to HDFS, like your namenode.
+* With the exception of the Accumulo RPM mentioned above you can install the rest of the RPMs all on a single node or
+a mix of nodes depending on your cluster configuration. All GeoWave files get installed into the `/usr/local/geowave/' directory

--- a/docs/content/080-install-from-source.adoc
+++ b/docs/content/080-install-from-source.adoc
@@ -6,9 +6,16 @@
 
 ==== GeoServer Versions
 
-GeoWave is currently built against GeoServer 2.6.1 and GeoTools 12.1 with the GeoTools version linked to the GeoServer
-version. If wish to deploy against a different version simply change the value in the pom and rebuild (see: building) -
-but no guarantees.
+GeoWave has to be built against specific versions of GeoWave and GeoTools. To see the currently supported versions look at
+the build matrix section of the .travis.yml file in the root directory of the project. All of the examples below use the variable
+$BUILD_ARGS to represent your choice of all the dependency versions.
+
+Example build args:
+
+[source, bash]
+----
+export BUILD_ARGS="-Daccumulo.version=1.6.0 -Dhadoop.version=2.5.0-cdh5.3.0 -Dgeotools.version=13.0 -Dgeoserver.version=2.7.0 -P cloudera"
+----
 
 ==== GeoServer Install
 
@@ -16,8 +23,8 @@ First we need to build the GeoServer plugin - from the GeoWave root directory:
 
 [source, bash]
 ----
-$ cd geowave-gt
-$ mvn package -Pgeotools-container-singlejar
+$ cd geowave-deploy
+$ mvn package -P geotools-container-singlejar $BUILD_ARGS
 ----
 
 let's assume you have GeoServer deployed in a Tomcat container in
@@ -25,7 +32,7 @@ let's assume you have GeoServer deployed in a Tomcat container in
 
 [source, bash]
 ----
-$ cp target/geowave-gt-*-geoserver-singlejar.jar /opt/tomcat/webapps/geoserver/WEB-INF/lib/
+$ cp geowave-deploy/target/*-geoserver-singlejar.jar /opt/tomcat/webapps/geoserver/WEB-INF/lib/
 ----
 
 and re-start Tomcat
@@ -43,6 +50,6 @@ This should be very familiar by now; from the geowave root directory:
 
 [source, bash]
 ----
-$ cd geowave-gt
-$ mvn package -Paccumulo-container-singlejar
+$ cd geowave-deploy
+$ mvn package -P accumulo-container-singlejar $BUILD_ARGS
 ----

--- a/docs/content/100-documentation.adoc
+++ b/docs/content/100-documentation.adoc
@@ -38,7 +38,7 @@ To preview the entire finished page web page or see the generated PDF you'll nee
 .Generate Documentation
 ----
  cd geowave
- mvn -P docs -pl docs install # <1>
+ mvn -P docs -pl docs install <1>
 ----
 <1> -pl docs = Process _only_ the docs module. Skips the javadoc generation step.
 
@@ -49,10 +49,10 @@ The source documents will be transformed and will be available for inspection in
 To build all the content used for the https://ngageoint.github.io/geowave/[GeoWave website] use the following command. The
 entire site, including both docs and javadocs, will be available for inspection in the `geowave/target/site/` directory.
 
-+[source, bash]
-+.Generate Website
-+----
-+ cd geowave
-+ mvn -P docs install
-+----
+[source, bash]
+.Generate Website
+----
+cd geowave
+mvn -P docs install
+----
 

--- a/docs/content/105-puppet.adoc
+++ b/docs/content/105-puppet.adoc
@@ -31,7 +31,7 @@ The port on which the Jetty application server will run, defaults to 8080.
 
 repo_base_url::
 Used with the optional geowave::repo class to point the local package management system at a source for GeoWave RPMs.
-The default location is http://s3.amazonaws.com/geowave-rpms/dev/noarch/
+The default location is http://s3.amazonaws.com/geowave-rpms/release/noarch/
 
 repo_enabled::
 To pick up an updated Accumulo iterator you'll need to restart the Accumulo service. As we don't want to pick up new
@@ -97,7 +97,7 @@ node 'c1-app-01' {
 
 === Puppet script management
 
-As mentioned in the overview the scripts are available from within the http://s3.amazonaws.com/geowave-rpms/index.html[GeoWave source tar bundle^]
+As mentioned in the overview the scripts are available from within the http://ngageoint.github.io/geowave/packages.html[GeoWave source tar bundle^]
 (Search for gz to filter the list) or you could use the RPM package to install and pick up future updates on your puppet server.
 
 ==== Source Archive

--- a/docs/content/packages.html
+++ b/docs/content/packages.html
@@ -246,7 +246,7 @@
         var currentTab, REFRESH_INTERVAL = 900000;
 
         var list = new S3List({
-            url: 'http://s3.amazonaws.com/geowave-rpms/',
+            url: '//s3.amazonaws.com/geowave-rpms/',
             list: ['repodata', '.html'],
             cache: REFRESH_INTERVAL - 1
         });


### PR DESCRIPTION
* Package download page in S3 replaced with a redirect to github.io page and updated existing doc references
* Fixed http(s) problem with download page, works with either now
* Additional explanation for -localingest Accumulo namespace argument
* Updated outdated build from source instructions referencing geowave-deploy directory
* Added some info about our new -P vendor profile build flag
* Removed Travis documentation generation restriction requiring JDK7