### PR TITLE
Publish PDF to S3 if available

### DIFF
--- a/docs/content/000-titlepage.adoc
+++ b/docs/content/000-titlepage.adoc
@@ -9,6 +9,8 @@ ifdef::backend-html5[]
 
 === icon:home[] http://ngageoint.github.io/geowave/[Site]
 
+=== icon:file-pdf-o[] https://s3.amazonaws.com/geowave/docs/documentation.pdf[PDF^]
+
 === icon:file-code-o[] http://ngageoint.github.io/geowave/apidocs/index.html[Javadoc]
 
 === icon:github[] https://github.com/ngageoint/geowave[GitHub]

--- a/docs/content/075-install-from-rpm.adoc
+++ b/docs/content/075-install-from-rpm.adoc
@@ -64,8 +64,9 @@ Restart Accumulo service
 
 === RPM Installation Notes
 
-* geowwave-cdh5-accumulo: This RPM will install the GeoWave Accumulo iterator into the local file system and then upload
+geowave-cdh5-accumulo: This RPM will install the GeoWave Accumulo iterator into the local file system and then upload
 it into HDFS using the `hadoop fs -put` command. This means of deployment requires that the RPM is installed on a node that
 has the correct binaries and configuration in place to push files to HDFS, like your namenode.
-* With the exception of the Accumulo RPM mentioned above you can install the rest of the RPMs all on a single node or
+
+With the exception of the Accumulo RPM mentioned above you can install the rest of the RPMs all on a single node or
 a mix of nodes depending on your cluster configuration. All GeoWave files get installed into the `/usr/local/geowave/' directory

--- a/packaging/rpm/admin-scripts/jenkins-build-rpm.sh
+++ b/packaging/rpm/admin-scripts/jenkins-build-rpm.sh
@@ -46,16 +46,25 @@ cd ${WORKSPACE}/${ARGS[buildroot]}/TARBALL/geowave
 rpm2cpio *.rpm | cpio -idmv
 
 # Remove what we don't want to distribute within the tarball
-rm -f *.rpm *.xml gh-pages.zip *.spec
+rm -f *.rpm *.xml *.spec
 
 # Extract the build metadata from one of the artifacts
 unzip -p geowave-accumulo.jar build.properties > build.properties
 
-# Archive things up and get rid of our temp area
+# Extract the pdf version of the docs so it's more visibly available
+tar xzf site.tar.gz --strip-components=1  site/documentation.pdf
+
+# Archive things, copy some artifacts up to AWS if available and get rid of our temp area
 cd ..
 githash=$(cat geowave/build.properties | grep project.scm.revision | sed -e 's/project.scm.revision=//g')
 version=$(cat geowave/build.properties | grep project.version | sed -e 's/project.version=//g')
 tar cvzf geowave-$version-${githash:0:7}.tar.gz geowave
+
+# Push our compiled docs to S3 if aws command has been installed
+if command -v aws >/dev/null 2>&1 ; then
+    aws s3 cp geowave/documentation.pdf s3://geowave/docs/
+fi
+
 rm -rf geowave
 
 echo '###### Copy rpm to repo and reindex'


### PR DESCRIPTION
* Extract documentation.pdf from site archive within our tarball distribution so it's more obvious
* Copy documentation.pdf to S3 if aws command is availble
* Link to pdf from our docs
* I added a docs directory to our geowave S3 bucket and added a policy that makes everything public
* Worked around an Asciidoc formatting bug where the end of one section uses a formatting construct like a list or a table and it does not correctly recognize the next section marker. I changed a bullet list into two paragraphs