### PR TITLE
Update Jenkins URL to use hostname instead of IP

### DIFF
--- a/packaging/rpm/admin-scripts/default-props.sh
+++ b/packaging/rpm/admin-scripts/default-props.sh
@@ -2,7 +2,7 @@
 # be externalized into this file
 
 # Our Jenkins server
-LOCAL_JENKINS=http://172.31.73.16:8080/jenkins
+LOCAL_JENKINS=http://jenkins-ui:8080/jenkins
 
 #CURL_ARGS='--socks5 localhost:1111'
 CURL_ARGS=''


### PR DESCRIPTION
I had to recreate the jenkins server in AWS to have it pick up an IAM role so the IP changed. This change will have it use hostname until such time as this setting goes away and we just start using public S3 buckets instead of jenkins for most of our artifacts.