### PR TITLE
Build, packaging and deployment updates for 0.8.7 refactor

### DIFF
--- a/core/cli/src/main/resources/geowave-tools-cmd-completion.sh
+++ b/core/cli/src/main/resources/geowave-tools-cmd-completion.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+#
+# Bash command completion script for the geowave cli tool
+#
+
+__geowave() {
+  local curr_arg=${COMP_WORDS[COMP_CWORD]}
+  local prev_arg=${COMP_WORDS[COMP_CWORD - 1]}
+  case ${COMP_CWORD} in
+  1)
+    COMPREPLY=( $(compgen -W '-clear -hdfsingest -hdfsstage -kafkastage -localingest -poststage -zkTx' -- $curr_arg ) )
+    ;;
+  2)
+     case ${prev_arg} in
+        -clear)
+            COMPREPLY=( $(compgen -W '-c --clear -dim --dimensionality -f --formats -h --help -i --instance-id -l --list -n --namespace -p --password -u --user -v --visibility -z --zookeepers' -- $curr_arg ) )
+            ;;
+        -hdfsingest)
+            COMPREPLY=( $(compgen -W '-b --base -c --clear -dim --dimensionality -f --formats -h --help -hdfs -hdfsbase -i --instance-id -jobtracker -l --list -n --namespace -p --password -resourceman -u --user -v --visibility -x --extension -z --zookeepers' -- $curr_arg ) )
+            ;;
+        -hdfsstage)
+            COMPREPLY=( $(compgen -W '-b --base -f --formats -h --help -hdfs -hdfsbase -l --list -x --extension' -- $curr_arg ) )
+            ;;
+        -kafkastage)
+            COMPREPLY=( $(compgen -W '-b --base -f --formats -h --help -kafkaprops -kafkatopic -l --list -x --extension' -- $curr_arg ) )
+            ;;
+        -localingest)
+            COMPREPLY=( $(compgen -W '-b --base -c --clear -dim --dimensionality -f --formats -h --help -i --instance-id -l --list -n --namespace -p --password -u --user -v --visibility -x --extension -z --zookeepers' -- $curr_arg ) )
+            ;;
+        -poststage)
+            COMPREPLY=( $(compgen -W '-c --clear -dim --dimensionality -f --formats -h --help -hdfs -hdfsbase -i --instance-id -jobtracker -l --list -n --namespace -p --password -resourceman -u --user -v --visibility -z --zookeepers' -- $curr_arg ) )
+            ;;
+        -zkTx)
+            COMPREPLY=( $(compgen -W '-h --help -i --instance-id -m --maximum -n --namespace -p --password -r --recipient -u --user -z --zookeepers' -- $curr_arg ) )
+            ;;
+     esac
+    ;;
+  *)
+    COMPREPLY=()
+    ;;
+  esac
+}
+
+complete -F __geowave geowave

--- a/core/cli/src/main/resources/geowave-tools.sh
+++ b/core/cli/src/main/resources/geowave-tools.sh
@@ -7,5 +7,8 @@ else
   JAVA="$JAVA_HOME/bin/java"
 fi
 
+# Ensure both our tools jar and anything in the plugins directory is on the classpath
+CLASSPATH="/usr/local/geowave/tools/geowave-tools.jar:/usr/local/geowave/tools/plugins/*"
+
 # Using -cp and the classname instead of -jar because Java 7 and below fail to auto-launch jars with more than 65k files
-exec $JAVA -cp "/usr/local/geowave/tools/geowave-tools.jar:/usr/local/geowave/tools/plugins/*" mil.nga.giat.geowave.core.cli.GeoWaveMain "$@"
+exec $JAVA -cp $CLASSPATH mil.nga.giat.geowave.core.cli.GeoWaveMain "$@"

--- a/deploy/packaging/puppet/geowave/manifests/accumulo.pp
+++ b/deploy/packaging/puppet/geowave/manifests/accumulo.pp
@@ -1,12 +1,12 @@
 class geowave::accumulo {
 
-  package { "geowave-${geowave::hadoop_vendor_version}-accumulo":
+  package { "geowave-${geowave::geowave_version}-${geowave::hadoop_vendor_version}-accumulo":
     ensure => latest,
     tag    => 'geowave-package',
   }
 
-  if !defined(Package["geowave-${geowave::hadoop_vendor_version}-core"]) {
-    package { "geowave-${geowave::hadoop_vendor_version}-core":
+  if !defined(Package["geowave-core"]) {
+    package { "geowave-core":
       ensure => latest,
       tag    => 'geowave-package',
     }

--- a/deploy/packaging/puppet/geowave/manifests/app.pp
+++ b/deploy/packaging/puppet/geowave/manifests/app.pp
@@ -1,8 +1,8 @@
 class geowave::app {
 
   $geowave_base_app_rpms = [
-    "geowave-${geowave::hadoop_vendor_version}-docs",
-    "geowave-${geowave::hadoop_vendor_version}-ingest",
+    "geowave-docs",
+    "geowave-${geowave::geowave_version}-${geowave::hadoop_vendor_version}-tools",
   ]
 
   package { $geowave_base_app_rpms:
@@ -10,8 +10,8 @@ class geowave::app {
     tag    => 'geowave-package',
   }
 
-  if !defined(Package["geowave-${geowave::hadoop_vendor_version}-core"]) {
-    package { "geowave-${geowave::hadoop_vendor_version}-core":
+  if !defined(Package["geowave-core"]) {
+    package { "geowave-core":
       ensure => latest,
       tag    => 'geowave-package',
     }

--- a/deploy/packaging/puppet/geowave/manifests/init.pp
+++ b/deploy/packaging/puppet/geowave/manifests/init.pp
@@ -1,10 +1,14 @@
 class geowave(
+  $geowave_version        = $geowave::params::geowave_version,
   $hadoop_vendor_version  = $geowave::params::hadoop_vendor_version,
   $install_accumulo       = $geowave::params::install_accumulo,
   $install_app            = $geowave::params::install_app,
   $install_app_server     = $geowave::params::install_app_server,
   $http_port              = $geowave::params::http_port
 ) inherits geowave::params {
+
+  if $geowave_version == undef { fail("geowave_version parameter is required") }
+  if $hadoop_vendor_version == undef { fail("hadoop_vendor_version parameter is required") }
 
   if $install_accumulo {
     class {'geowave::accumulo':}

--- a/deploy/packaging/puppet/geowave/manifests/params.pp
+++ b/deploy/packaging/puppet/geowave/manifests/params.pp
@@ -1,4 +1,5 @@
 class geowave::params {
+  $geowave_version = undef
   $hadoop_vendor_version = undef
   $install_accumulo = false
   $install_app = false

--- a/deploy/packaging/puppet/geowave/manifests/server.pp
+++ b/deploy/packaging/puppet/geowave/manifests/server.pp
@@ -2,14 +2,14 @@ class geowave::server {
 
   $http_port = $geowave::http_port
 
-  package { "geowave-${geowave::hadoop_vendor_version}-jetty":
+  package { "geowave-${geowave::geowave_version}-${geowave::hadoop_vendor_version}-jetty":
     ensure => latest,
     tag    => 'geowave-package',
     notify => Service['geowave']
   }
 
-  if !defined(Package["geowave-${geowave::hadoop_vendor_version}-core"]) {
-    package { "geowave-${geowave::hadoop_vendor_version}-core":
+  if !defined(Package["geowave-core"]) {
+    package { "geowave-core":
       ensure => latest,
       tag    => 'geowave-package',
     }
@@ -21,7 +21,7 @@ class geowave::server {
     owner   => 'geowave',
     group   => 'geowave',
     mode    => '644',
-    require => Package["geowave-${geowave::hadoop_vendor_version}-jetty"],
+    require => Package["geowave-${geowave::geowave_version}-${geowave::hadoop_vendor_version}-jetty"],
     notify  => Service['geowave']
   }
 

--- a/deploy/packaging/rpm/admin-scripts/jenkins-build-geowave.sh
+++ b/deploy/packaging/rpm/admin-scripts/jenkins-build-geowave.sh
@@ -6,6 +6,13 @@
 
 cd $WORKSPACE/deploy
 
+# Create an archive of all the ingest format plugins
+mkdir -p target/plugins >/dev/null 2>&1
+pushd target/plugins
+find $WORKSPACE/extensions/formats -name "*.jar" -exec cp {} . \;
+tar cvzf ../plugins.tar.gz *.jar
+popd
+
 # Build each of the "fat jar" artifacts and rename to remove any version strings in the file name
 
 mvn package -P geotools-container-singlejar $BUILD_ARGS "$@"

--- a/deploy/packaging/rpm/admin-scripts/jenkins-build-rpm.sh
+++ b/deploy/packaging/rpm/admin-scripts/jenkins-build-rpm.sh
@@ -32,7 +32,7 @@ echo '###### Build rpm'
 
 ./rpm.sh \
     --command build \
-    --rpmname ${ARGS[rpmname]} \
+    --vendor-version ${ARGS[vendor-version]} \
     --buildarg ba # ba = build all (binary and source rpms)
 
 echo '###### Build tarball distribution archive'
@@ -58,7 +58,7 @@ tar xzf site.tar.gz --strip-components=1  site/documentation.pdf
 cd ..
 githash=$(cat geowave/build.properties | grep project.scm.revision | sed -e 's/project.scm.revision=//g')
 version=$(cat geowave/build.properties | grep project.version | sed -e 's/project.version=//g')
-tar cvzf geowave-$version-${githash:0:7}.tar.gz geowave
+tar cvzf geowave-${ARGS[vendor-version]}-$version-${githash:0:7}.tar.gz geowave
 
 # Push our compiled docs to S3 if aws command has been installed
 if command -v aws >/dev/null 2>&1 ; then

--- a/deploy/packaging/rpm/admin-scripts/rpm-functions.sh
+++ b/deploy/packaging/rpm/admin-scripts/rpm-functions.sh
@@ -65,6 +65,27 @@ parseVersion() {
     echo $(unzip -p SOURCES/geowave-accumulo.jar build.properties | grep "project.version=" | sed -e 's/"//g' -e 's/-SNAPSHOT//g' -e 's/project.version=//g')
 }
 
+# Given a version string, remove all dots and patch version dash labels, then take the first three sets of digits
+# and interpret as an integer to determine the install priority number used by alternatives in an automated way
+parsePriorityFromVersion() {
+    # Drop trailing bug fix or pre-release labels (0.8.8-alpha2 or 0.8.8-1)
+    VERSION=${1%-*}
+
+    # Truncate the version string after the first three groups delimited by dots
+    VERSION=$(echo $VERSION | cut -d '.' -f1-3)
+
+    # Remove non digits (dots)
+    VERSION=$(echo ${VERSION//[^0-9]/})
+
+    # If empty or not a number is the result return a low priority
+    if [ -z "$VERSION" ] || [ "$VERSION" -ne "$VERSION" ] ; then
+        echo 1
+    else
+        # Interpret as a base 10 number (drop leading zeros)
+        echo $(( 10#$VERSION ))
+    fi
+}
+
 # Default build function, should be overridden by local script if more complex
 build() {
 	# Create the rpms

--- a/deploy/packaging/rpm/centos/6/SOURCES/bash_profile.sh
+++ b/deploy/packaging/rpm/centos/6/SOURCES/bash_profile.sh
@@ -11,6 +11,6 @@ if [ "x" == "x$GEOSERVER_DATA_DIR" ]; then
 fi
 
 # Sourcing of this file does not always work with default profile settings so we'll ensure with this
-if [ -f /etc/bash_completion.d/geowave-ingest-cmd-completion.sh ] && ! shopt -oq posix; then
-    . /etc/bash_completion.d/geowave-ingest-cmd-completion.sh
+if [ -f /etc/bash_completion.d/geowave-tools-cmd-completion.sh ] && ! shopt -oq posix; then
+    . /etc/bash_completion.d/geowave-tools-cmd-completion.sh
 fi

--- a/deploy/packaging/rpm/centos/6/rpm.sh
+++ b/deploy/packaging/rpm/centos/6/rpm.sh
@@ -21,17 +21,21 @@ ARTIFACT_03_URL=$LOCAL_JENKINS/job/${ARGS[job]}/lastSuccessfulBuild/artifact/dep
 ARTIFACT_04_URL=$LOCAL_JENKINS/job/${ARGS[job]}/lastSuccessfulBuild/artifact/deploy/target/jace-linux-amd64-release.tar.gz
 ARTIFACT_05_URL=$LOCAL_JENKINS/job/${ARGS[job]}/lastSuccessfulBuild/artifact/deploy/target/jace-source.tar.gz
 ARTIFACT_06_URL=$LOCAL_JENKINS/job/${ARGS[job]}/lastSuccessfulBuild/artifact/deploy/target/geowave-tools.jar
-ARTIFACT_07_URL=$LOCAL_JENKINS/job/${ARGS[job]}/lastSuccessfulBuild/artifact/target/site.tar.gz
-ARTIFACT_08_URL=$LOCAL_JENKINS/job/${ARGS[job]}/lastSuccessfulBuild/artifact/deploy/target/puppet-scripts.tar.gz
-ARTIFACT_09_URL=$LOCAL_JENKINS/job/${ARGS[job]}/lastSuccessfulBuild/artifact/docs/target/manpages.tar.gz
-ARTIFACT_10_URL=$LOCAL_JENKINS/userContent/geoserver/${ARGS[geoserver]}
+ARTIFACT_07_URL=$LOCAL_JENKINS/job/${ARGS[job]}/lastSuccessfulBuild/artifact/deploy/target/plugins.tar.gz
+ARTIFACT_08_URL=$LOCAL_JENKINS/job/${ARGS[job]}/lastSuccessfulBuild/artifact/target/site.tar.gz
+ARTIFACT_09_URL=$LOCAL_JENKINS/job/${ARGS[job]}/lastSuccessfulBuild/artifact/deploy/target/puppet-scripts.tar.gz
+ARTIFACT_10_URL=$LOCAL_JENKINS/job/${ARGS[job]}/lastSuccessfulBuild/artifact/docs/target/manpages.tar.gz
+ARTIFACT_11_URL=$LOCAL_JENKINS/userContent/geoserver/${ARGS[geoserver]}
 RPM_ARCH=noarch
+
+GEOWAVE_VERSION=$(parseVersion)
 
 case ${ARGS[command]} in
     build) rpmbuild \
                 --define "_topdir $(pwd)" \
-                --define "_name ${ARGS[rpmname]}" \
-                --define "_version $(parseVersion)" \
+                --define "_version $GEOWAVE_VERSION" \
+                --define "_vendor_version ${ARGS[vendor-version]}" \
+                --define "_priority $(parsePriorityFromVersion $GEOWAVE_VERSION)" \
                 $(buildArg "${ARGS[buildarg]}") SPECS/*.spec ;;
     clean) clean ;;
    update)
@@ -44,6 +48,7 @@ case ${ARGS[command]} in
         update_artifact $ARTIFACT_07_URL;
         update_artifact $ARTIFACT_08_URL;
         update_artifact $ARTIFACT_09_URL;
-        update_artifact $ARTIFACT_10_URL geoserver.zip; ;;
+        update_artifact $ARTIFACT_10_URL;
+        update_artifact $ARTIFACT_11_URL geoserver.zip; ;;
         *) about ;;
 esac

--- a/deploy/src/main/resources/build.properties
+++ b/deploy/src/main/resources/build.properties
@@ -2,6 +2,7 @@
 project.version=${project.parent.version}
 project.branch=${scmBranch}
 project.scm.revision=${buildNumber}
+project.build.args=${env.BUILD_ARGS}
 
 # Build Details
 build.timestamp=${build.timestamp}


### PR DESCRIPTION
This is hopefully all the changes needed to update all the Jenkins builds and do a final install test on both Cloudera and Hortonworks. The final commit before declaring the 0.8.7 final release will contain the updated documentation.

* core, docs and puppet rpms are no longer vendor prefixed
* All other rpms now have geowave and version in the name ex: geowave-0.8.7-hdp2 to support concurrent vendor and version installs
  * Using the Linux alternatives utility only one install will be active
* Puppet scripts updated to use new RPM names
* Updated Jenkins build scripts
