### PR TITLE
GEOWAVE-143

### DIFF
--- a/core/store/src/main/java/mil/nga/giat/geowave/core/store/DataStore.java
+++ b/core/store/src/main/java/mil/nga/giat/geowave/core/store/DataStore.java
@@ -9,6 +9,7 @@ import mil.nga.giat.geowave.core.store.adapter.WritableDataAdapter;
 import mil.nga.giat.geowave.core.store.data.VisibilityWriter;
 import mil.nga.giat.geowave.core.store.index.Index;
 import mil.nga.giat.geowave.core.store.query.Query;
+import mil.nga.giat.geowave.core.store.query.QueryOptions;
 
 /**
  * A DataStore can both ingest and query data based on persisted indices and
@@ -264,6 +265,29 @@ public interface DataStore
 	public <T> CloseableIterator<T> query(
 			Index index,
 			final Query query );
+
+	/**
+	 * Returns all data in this data store that matches the query parameter
+	 * within the index described by the index passed in. All data types that
+	 * match the query will be returned as an instance of the native data type
+	 * that was originally ingested. Additional query options will be applied to
+	 * results
+	 * 
+	 * @param index
+	 *            The index information to query against. All data within the
+	 *            index of this index ID will be queried and returned.
+	 * @param query
+	 *            The description of the query to be performed
+	 * @param queryOptions
+	 *            Additional options to be applied to the query results
+	 * @return An iterator on all results that match the query. The iterator
+	 *         implements Closeable and it is best practice to close the
+	 *         iterator after it is no longer needed.
+	 */
+	public <T> CloseableIterator<T> query(
+			Index index,
+			final Query query,
+			final QueryOptions queryOptions );
 
 	/**
 	 * Returns all data in this data store that matches the query parameter

--- a/core/store/src/main/java/mil/nga/giat/geowave/core/store/query/QueryOptions.java
+++ b/core/store/src/main/java/mil/nga/giat/geowave/core/store/query/QueryOptions.java
@@ -1,0 +1,45 @@
+package mil.nga.giat.geowave.core.store.query;
+
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * Container object that encapsulates additional options to be applied to a
+ * {@link Query}
+ * 
+ * @since 0.8.7
+ */
+public class QueryOptions
+{
+	private Collection<String> fieldIds;
+
+	/**
+	 * @param fieldIds
+	 *            the desired subset of fieldIds to be included in query results
+	 */
+	public QueryOptions(
+			Collection<String> fieldIds ) {
+		super();
+		this.fieldIds = fieldIds;
+	}
+
+	/**
+	 * @return the fieldIds or an empty List, will never return null
+	 */
+	public Collection<String> getFieldIds() {
+		if (fieldIds == null) {
+			fieldIds = Collections.emptyList();
+		}
+		return fieldIds;
+	}
+
+	/**
+	 * @param fieldIds
+	 *            the desired subset of fieldIds to be included in query results
+	 */
+	public void setFieldIds(
+			Collection<String> fieldIds ) {
+		this.fieldIds = fieldIds;
+	}
+
+}

--- a/extensions/datastores/accumulo/src/main/java/mil/nga/giat/geowave/datastore/accumulo/AccumuloDataStore.java
+++ b/extensions/datastores/accumulo/src/main/java/mil/nga/giat/geowave/datastore/accumulo/AccumuloDataStore.java
@@ -10,7 +10,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import mil.nga.giat.geowave.core.index.ByteArrayId;
 import mil.nga.giat.geowave.core.index.ByteArrayRange;
 import mil.nga.giat.geowave.core.index.ByteArrayUtils;
@@ -37,6 +36,7 @@ import mil.nga.giat.geowave.core.store.filter.MultiIndexDedupeFilter;
 import mil.nga.giat.geowave.core.store.index.Index;
 import mil.nga.giat.geowave.core.store.index.IndexStore;
 import mil.nga.giat.geowave.core.store.query.Query;
+import mil.nga.giat.geowave.core.store.query.QueryOptions;
 import mil.nga.giat.geowave.datastore.accumulo.metadata.AccumuloAdapterStore;
 import mil.nga.giat.geowave.datastore.accumulo.metadata.AccumuloDataStatisticsStore;
 import mil.nga.giat.geowave.datastore.accumulo.metadata.AccumuloIndexStore;
@@ -72,6 +72,8 @@ import org.apache.hadoop.io.Text;
 import org.apache.log4j.Logger;
 
 import com.google.common.collect.Iterators;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
  * This is the Accumulo implementation of the data store. It requires an
@@ -998,6 +1000,7 @@ public class AccumuloDataStore implements
 					adapterStore,
 					limit,
 					scanCallback,
+					null,
 					authorizations);
 		}
 		catch (final IOException e) {
@@ -1021,6 +1024,7 @@ public class AccumuloDataStore implements
 			final AdapterStore adapterStore,
 			final Integer limit,
 			final ScanCallback<?> scanCallback,
+			final QueryOptions queryOptions,
 			final String... authorizations ) {
 		// query the indices that are supported for this query object, and these
 		// data adapter Ids
@@ -1054,6 +1058,10 @@ public class AccumuloDataStore implements
 			}
 			else {
 				continue;
+			}
+			if ((queryOptions != null) && (!queryOptions.getFieldIds().isEmpty())) {
+				// results should contain subset of fieldIds
+				accumuloQuery.setFieldIds(queryOptions.getFieldIds());
 			}
 			results.add(accumuloQuery.query(
 					accumuloOperations,
@@ -1095,7 +1103,20 @@ public class AccumuloDataStore implements
 		return query(
 				index,
 				query,
+				null,
 				null);
+	}
+
+	@Override
+	public <T> CloseableIterator<T> query(
+			Index index,
+			final Query query,
+			final QueryOptions queryOptions ) {
+		return query(
+				index,
+				query,
+				null,
+				queryOptions);
 	}
 
 	@Override
@@ -1106,7 +1127,8 @@ public class AccumuloDataStore implements
 		return query(
 				index,
 				query,
-				(Integer) limit);
+				(Integer) limit,
+				null);
 	}
 
 	@Override
@@ -1123,7 +1145,8 @@ public class AccumuloDataStore implements
 	private <T> CloseableIterator<T> query(
 			final Index index,
 			final Query query,
-			final Integer limit ) {
+			final Integer limit,
+			final QueryOptions queryOptions ) {
 		if ((query != null) && !query.isSupported(index)) {
 			throw new IllegalArgumentException(
 					"Index does not support the query");
@@ -1138,6 +1161,8 @@ public class AccumuloDataStore implements
 								}).iterator()),
 				adapterStore,
 				limit,
+				null,
+				queryOptions,
 				null);
 	}
 
@@ -1199,6 +1224,7 @@ public class AccumuloDataStore implements
 						}),
 				limit,
 				scanCallback,
+				null,
 				authorizations);
 	}
 

--- a/test/src/test/java/mil/nga/giat/geowave/test/GeoWaveITSuite.java
+++ b/test/src/test/java/mil/nga/giat/geowave/test/GeoWaveITSuite.java
@@ -3,13 +3,13 @@ package mil.nga.giat.geowave.test;
 import mil.nga.giat.geowave.test.mapreduce.BasicMapReduceIT;
 import mil.nga.giat.geowave.test.mapreduce.GeoWaveKMeansIT;
 import mil.nga.giat.geowave.test.mapreduce.KDERasterResizeIT;
+import mil.nga.giat.geowave.test.query.AttributesSubsetQueryIT;
 import mil.nga.giat.geowave.test.service.GeoServerIT;
 import mil.nga.giat.geowave.test.service.GeoWaveIngestGeoserverIT;
 import mil.nga.giat.geowave.test.service.GeoWaveServicesIT;
 import mil.nga.giat.geowave.test.service.ServicesTestEnvironment;
 
 import org.junit.AfterClass;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
@@ -25,7 +25,8 @@ import org.junit.runners.Suite.SuiteClasses;
 	GeoWaveKMeansIT.class,
 	GeoServerIT.class,
 	GeoWaveServicesIT.class,
-	GeoWaveIngestGeoserverIT.class
+	GeoWaveIngestGeoserverIT.class,
+	AttributesSubsetQueryIT.class
 })
 public class GeoWaveITSuite
 {

--- a/test/src/test/java/mil/nga/giat/geowave/test/query/AttributesSubsetQueryIT.java
+++ b/test/src/test/java/mil/nga/giat/geowave/test/query/AttributesSubsetQueryIT.java
@@ -1,0 +1,343 @@
+package mil.nga.giat.geowave.test.query;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+
+import mil.nga.giat.geowave.adapter.vector.FeatureDataAdapter;
+import mil.nga.giat.geowave.core.geotime.GeometryUtils;
+import mil.nga.giat.geowave.core.geotime.IndexType;
+import mil.nga.giat.geowave.core.geotime.store.query.SpatialQuery;
+import mil.nga.giat.geowave.core.store.CloseableIterator;
+import mil.nga.giat.geowave.core.store.DataStore;
+import mil.nga.giat.geowave.core.store.index.Index;
+import mil.nga.giat.geowave.core.store.query.QueryOptions;
+import mil.nga.giat.geowave.datastore.accumulo.AccumuloDataStore;
+import mil.nga.giat.geowave.test.GeoWaveTestEnvironment;
+
+import org.apache.log4j.Logger;
+import org.geotools.data.DataUtilities;
+import org.geotools.feature.SchemaException;
+import org.geotools.feature.simple.SimpleFeatureBuilder;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.opengis.feature.simple.SimpleFeature;
+import org.opengis.feature.simple.SimpleFeatureType;
+
+import com.vividsolutions.jts.geom.Coordinate;
+import com.vividsolutions.jts.geom.Envelope;
+
+public class AttributesSubsetQueryIT extends
+		GeoWaveTestEnvironment
+{
+	private static final Logger LOGGER = Logger.getLogger(AttributesSubsetQueryIT.class);
+
+	private static SimpleFeatureType simpleFeatureType;
+	private static FeatureDataAdapter dataAdapter;
+	private static DataStore dataStore;
+
+	private static final Index INDEX = IndexType.SPATIAL_VECTOR.createDefaultIndex();
+
+	// constants for attributes of SimpleFeatureType
+	private static final String CITY_ATTRIBUTE = "city";
+	private static final String STATE_ATTRIBUTE = "state";
+	private static final String POPULATION_ATTRIBUTE = "population";
+	private static final String LAND_AREA_ATTRIBUTE = "landArea";
+	private static final String GEOMETRY_ATTRIBUTE = "geometry";
+
+	private static final Collection<String> ALL_ATTRIBUTES = Arrays.asList(
+			CITY_ATTRIBUTE,
+			STATE_ATTRIBUTE,
+			POPULATION_ATTRIBUTE,
+			LAND_AREA_ATTRIBUTE,
+			GEOMETRY_ATTRIBUTE);
+
+	// points used to construct bounding box for queries
+	private static final Coordinate GUADALAJARA = new Coordinate(
+			-103.3500,
+			20.6667);
+	private static final Coordinate ATLANTA = new Coordinate(
+			-84.3900,
+			33.7550);
+
+	@BeforeClass
+	public static void setup()
+			throws IOException {
+
+		GeoWaveTestEnvironment.setup();
+
+		simpleFeatureType = getSimpleFeatureType();
+
+		dataAdapter = new FeatureDataAdapter(
+				simpleFeatureType);
+
+		dataStore = new AccumuloDataStore(
+				accumuloOperations);
+
+		ingestSampleData();
+	}
+
+	@Test
+	public void testResultsContainAllAttributes()
+			throws IOException {
+
+		final CloseableIterator<SimpleFeature> matches = dataStore.query(
+				INDEX,
+				new SpatialQuery(
+						GeometryUtils.GEOMETRY_FACTORY.toGeometry(new Envelope(
+								GUADALAJARA,
+								ATLANTA))));
+
+		// query expects to match 3 cities from Texas, which should each contain
+		// non-null values for each SimpleFeature attribute
+		verifyResults(
+				matches,
+				3,
+				ALL_ATTRIBUTES);
+	}
+
+	@Test
+	public void testResultsContainCityOnly()
+			throws IOException {
+
+		final List<String> attributesSubset = Arrays.asList(CITY_ATTRIBUTE);
+
+		final CloseableIterator<SimpleFeature> results = dataStore.query(
+				INDEX,
+				new SpatialQuery(
+						GeometryUtils.GEOMETRY_FACTORY.toGeometry(new Envelope(
+								GUADALAJARA,
+								ATLANTA))),
+				new QueryOptions(
+						attributesSubset));
+
+		// query expects to match 3 cities from Texas, which should each contain
+		// non-null values for a subset of attributes (city) and nulls for the
+		// rest
+		verifyResults(
+				results,
+				3,
+				attributesSubset);
+	}
+
+	@Test
+	public void testResultsContainCityAndPopulation()
+			throws IOException {
+
+		final List<String> attributesSubset = Arrays.asList(
+				CITY_ATTRIBUTE,
+				POPULATION_ATTRIBUTE);
+
+		final CloseableIterator<SimpleFeature> results = dataStore.query(
+				INDEX,
+				new SpatialQuery(
+						GeometryUtils.GEOMETRY_FACTORY.toGeometry(new Envelope(
+								GUADALAJARA,
+								ATLANTA))),
+				new QueryOptions(
+						attributesSubset));
+
+		// query expects to match 3 cities from Texas, which should each contain
+		// non-null values for a subset of attributes (city, population) and
+		// nulls for the rest
+		verifyResults(
+				results,
+				3,
+				attributesSubset);
+	}
+
+	private void verifyResults(
+			final CloseableIterator<SimpleFeature> results,
+			final int numExpectedResults,
+			final Collection<String> attributesExpected )
+			throws IOException {
+
+		int numResults = 0;
+		SimpleFeature currentFeature;
+		Object currentAttributeValue;
+
+		while (results.hasNext()) {
+
+			currentFeature = results.next();
+			numResults++;
+
+			for (String currentAttribute : ALL_ATTRIBUTES) {
+
+				currentAttributeValue = currentFeature.getAttribute(currentAttribute);
+
+				if (attributesExpected.contains(currentAttribute) || currentAttribute.equals(GEOMETRY_ATTRIBUTE)) {
+					// geometry will always be included since indexed by spatial
+					// dimensionality
+					Assert.assertNotNull(
+							"Expected non-null " + currentAttribute + " value!",
+							currentAttributeValue);
+				}
+				else {
+					Assert.assertNull(
+							"Expected null " + currentAttribute + " value!",
+							currentAttributeValue);
+				}
+			}
+		}
+
+		results.close();
+
+		Assert.assertEquals(
+				"Unexpected number of query results",
+				numExpectedResults,
+				numResults);
+	}
+
+	private static SimpleFeatureType getSimpleFeatureType() {
+
+		SimpleFeatureType type = null;
+
+		try {
+			type = DataUtilities.createType(
+					"testCityData",
+					CITY_ATTRIBUTE + ":String," + STATE_ATTRIBUTE + ":String," + POPULATION_ATTRIBUTE + ":Double," + LAND_AREA_ATTRIBUTE + ":Double," + GEOMETRY_ATTRIBUTE + ":Geometry");
+		}
+		catch (SchemaException e) {
+			LOGGER.error(
+					"Unable to create SimpleFeatureType",
+					e);
+		}
+
+		return type;
+	}
+
+	private static void ingestSampleData() {
+
+		LOGGER.info("Ingesting canned data...");
+
+		dataStore.ingest(
+				dataAdapter,
+				INDEX,
+				buildCityDataSet().iterator());
+
+		LOGGER.info("Ingest complete.");
+	}
+
+	private static List<SimpleFeature> buildCityDataSet() {
+
+		final List<SimpleFeature> points = new ArrayList<>();
+
+		// http://en.wikipedia.org/wiki/List_of_United_States_cities_by_population
+		points.add(buildSimpleFeature(
+				"New York",
+				"New York",
+				8405837,
+				302.6,
+				new Coordinate(
+						-73.9385,
+						40.6643)));
+		points.add(buildSimpleFeature(
+				"Los Angeles",
+				"California",
+				3884307,
+				468.7,
+				new Coordinate(
+						-118.4108,
+						34.0194)));
+		points.add(buildSimpleFeature(
+				"Chicago",
+				"Illinois",
+				2718782,
+				227.6,
+				new Coordinate(
+						-87.6818,
+						41.8376)));
+		points.add(buildSimpleFeature(
+				"Houston",
+				"Texas",
+				2195914,
+				599.6,
+				new Coordinate(
+						-95.3863,
+						29.7805)));
+		points.add(buildSimpleFeature(
+				"Philadelphia",
+				"Pennsylvania",
+				1553165,
+				134.1,
+				new Coordinate(
+						-75.1333,
+						40.0094)));
+		points.add(buildSimpleFeature(
+				"Phoenix",
+				"Arizona",
+				1513367,
+				516.7,
+				new Coordinate(
+						-112.088,
+						33.5722)));
+		points.add(buildSimpleFeature(
+				"San Antonio",
+				"Texas",
+				1409019,
+				460.9,
+				new Coordinate(
+						-98.5251,
+						29.4724)));
+		points.add(buildSimpleFeature(
+				"San Diego",
+				"California",
+				1355896,
+				325.2,
+				new Coordinate(
+						-117.135,
+						32.8153)));
+		points.add(buildSimpleFeature(
+				"Dallas",
+				"Texas",
+				1257676,
+				340.5,
+				new Coordinate(
+						-96.7967,
+						32.7757)));
+		points.add(buildSimpleFeature(
+				"San Jose",
+				"California",
+				998537,
+				176.5,
+				new Coordinate(
+						-121.8193,
+						37.2969)));
+
+		return points;
+	}
+
+	private static SimpleFeature buildSimpleFeature(
+			String city,
+			String state,
+			double population,
+			double landArea,
+			Coordinate coordinate ) {
+
+		final SimpleFeatureBuilder builder = new SimpleFeatureBuilder(
+				simpleFeatureType);
+
+		builder.set(
+				CITY_ATTRIBUTE,
+				city);
+		builder.set(
+				STATE_ATTRIBUTE,
+				state);
+		builder.set(
+				POPULATION_ATTRIBUTE,
+				population);
+		builder.set(
+				LAND_AREA_ATTRIBUTE,
+				landArea);
+		builder.set(
+				GEOMETRY_ATTRIBUTE,
+				GeometryUtils.GEOMETRY_FACTORY.createPoint(coordinate));
+
+		return builder.buildFeature(UUID.randomUUID().toString());
+	}
+
+}


### PR DESCRIPTION
Initial stab at #143 including Integration Test to demonstrate approach and results.  Feedback welcome!

##### Brief summary:

I added a new query method to the DataStore that allows one to provide a desired subset of attributes to be included in query results.  Research into available iterators to accomplish this goal within the tablets led me to `ColumnQualifierFilter` and [this discussion](http://apache-accumulo.1065345.n5.nabble.com/ColumnQualifierFilter-td1580.html), which recommends leveraging `scanner.fetchColumn(Text colFam, Text colQual)` for this purpose.

The integration test ingests sample data for the 10 largest cities in the US (city, state, population, land area, coordinates) and demonstrates 3 queries against this data set.  Each query constructs a bounding box designed to match 3 cities from Texas.  One query leverages an existing query method to return all attributes.  The other two queries leverage the new query method to request different subsets of attributes asserting for the correct presence (null vs. not-null) of each attribute in the results.

Please let me know if I missed or misinterpreted anything...