### PR TITLE
Stop adding timestamp to javadocs html

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -528,6 +528,9 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
 				<version>2.9.1</version>
+				<configuration>
+					<notimestamp>true</notimestamp>
+				</configuration>
 				<executions>
 					<execution>
 						<id>aggregate</id>


### PR DESCRIPTION
One of the causes of our repo bloat was the javadocs constantly changing due to a generated timestamp. The configuration seems to have no effect when set within the aggregate/site phase but works as a global setting.