### PR TITLE
Corrected one command and added a tip on inspecting configs

### DIFF
--- a/docs/content/085-accumulo-config.adoc
+++ b/docs/content/085-accumulo-config.adoc
@@ -39,6 +39,19 @@ exit
 These manual configuration steps have to be performed before attempting to create GeoWave index tables. After the initial configuration
 you may elect to do further user and namespace creation and configuring to provide isolation between groups and data sets.
 
+=== Managing
+
+After installing a number of different iterators you may want to figure out which iterators have been configured.
+
+[source, bash]
+----
+# Print all configuration and grep for line containing vfs.context configuration and also show the following line
+accumulo shell -u root -p ROOT_PWD -e "config -np" | grep -A 1 general.vfs.context.classpath
+----
+
+You will get back a listing of context classpath override configurations which map the application or user context you configured to
+a specific iterator jar in HDFS.
+
 === Versioning
 
 It's of critical importance to ensure that the various GeoWave components are all the same version and that your client is of the same version

--- a/docs/content/105-puppet.adoc
+++ b/docs/content/105-puppet.adoc
@@ -121,5 +121,5 @@ rest of the cluster using Puppet.
 [source, bash]
 ----
 rpm -Uvh http://s3.amazonaws.com/geowave-rpms/release/noarch/geowave-repo-1.0-3.noarch.rpm
-yum install geowave-cdh5-puppet
+yum --enablerepo=geowave install geowave-puppet
 ----


### PR DESCRIPTION

Fixed a yum command and added a handy one-liner to figure out what iterators have been configured.

```
[spohnae@c1-app-02 ~]$ accumulo shell -u root -p ROOT_PWD -e "config -np" | grep -A 1 general.vfs.contex
t.classpath                                                                                          
site       | general.vfs.context.classpath.geolife .................. | 
system     |    @override ........................................... | hdfs://c1-master.ec2.internal:8020/accumulo/classpath/geowave/geowave-accumulo.jar
site       | general.vfs.context.classpath.geotools ................. | 
system     |    @override ........................................... | hdfs://c1-master.ec2.internal:8020/accumulo/classpath/geowave/geowave-accumulo.jar
site       | general.vfs.context.classpath.geowaverwg ............... | 
system     |    @override ........................................... | hdfs://c1-master.ec2.internal:8020/accumulo/classpath/geowaverwg/[^.].*.jar
site       | general.vfs.context.classpath.glides ................... | 
system     |    @override ........................................... | hdfs://c1-master.ec2.internal:8020/accumulo/classpath/geowave/[^.].*.jar
site       | general.vfs.context.classpath.landsat .................. | 
system     |    @override ........................................... | hdfs://c1-master.ec2.internal:8020/accumulo/classpath/geowave-0.8.7/[^.].*.jar
```