### PR TITLE
Support CDH single user install

### DIFF
--- a/deploy/packaging/rpm/centos/6/SOURCES/deploy-geowave-to-hdfs.sh
+++ b/deploy/packaging/rpm/centos/6/SOURCES/deploy-geowave-to-hdfs.sh
@@ -2,6 +2,9 @@
 #
 # Upload geowave-accumulo.jar into HDFS
 # Use a naming convention within the HDFS directory structure to differentiate versions
+# Attempt to use a variety of common HDFS root usernames an optional user arg will override
+#
+# deploy-geowave-to-hdfs.sh [--user HDFS_ROOT_USERNAME]
 #
 
 # Test for installed apps required to run this script
@@ -21,9 +24,21 @@ dependency_tests
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ACCUMULO_USER=accumulo
 
+# Parse any arguments passed to the script
+declare -A ARGS
+while [ $# -gt 0 ]; do
+    case "$1" in
+        *) NAME="${1:2}"; shift; ARGS[$NAME]="$1" ;;
+    esac
+    shift
+done
+
 determine_hdfs_user() {
     # Various usernames distros configure to be the one with "root" HDFS permissions
-    HADOOP_USERS=('hdfs' 'hadoop')
+    HADOOP_USERS=('hdfs' 'hadoop' 'cloudera-scm')
+    if [ ! -z ${ARGS[user]} ]; then # Use custom user if provided
+        HADOOP_USERS=( ${ARGS[user]} )
+    fi
     HADOOP_USER=
     for user in "${HADOOP_USERS[@]}"
     do

--- a/docs/content/075-install-from-rpm.adoc
+++ b/docs/content/075-install-from-rpm.adoc
@@ -82,9 +82,14 @@ geowave-home - status is auto.
 Current `best' version is /usr/local/geowave-0.8.7-hdp2.
 ----
 
-geowave-cdh5-accumulo: This RPM will install the GeoWave Accumulo iterator into the local file system and then upload
+geowave-*-accumulo: This RPM will install the GeoWave Accumulo iterator into the local file system and then upload
 it into HDFS using the `hadoop fs -put` command. This means of deployment requires that the RPM is installed on a node that
-has the correct binaries and configuration in place to push files to HDFS, like your namenode.
+has the correct binaries and configuration in place to push files to HDFS, like your namenode. We also need to set the ownership
+and permissions correctly within HDFS and as such need to execute the script as a user that has superuser permisisons in HDFS.
+This user varies by Hadoop distribution vendor. If the Accumulo RPM installation fails, check the install log located at
+`/usr/local/geowave/accumulo/geowave-to-hdfs.log` for errors. The script can be re-run manually if there was a problem that
+can be corrected like the HDFS service was not started. If a non-default user was used to install Hadoop you can specify a user
+that has permissions to upload with the --user argument `/usr/local/geowave/accumulo/deploy-to-geowave-to-hdfs.sh --user my-hadoop-user`
 
-With the exception of the Accumulo RPM mentioned above you can install the rest of the RPMs all on a single node or
-a mix of nodes depending on your cluster configuration. All GeoWave files get installed into the `/usr/local/geowave/' directory
+With the exception of the Accumulo RPM mentioned above there are no restrictions on where you install RPMs. You can install
+the rest of the RPMs all on a single node for development use or a mix of nodes depending on your cluster configuration.


### PR DESCRIPTION
Addresses issue #423 and will add one additional HDFS user to the list of default usernames array. If a custom user we'll never be able to guess was used add a --user argument to the script so it doesn't have to be modified when re-run manually. 