### PR TITLE
Issue #425 Optimize spatial queries to use prepared geometries.

### DIFF
--- a/extensions/adapters/vector/src/test/java/mil/nga/giat/geowave/adapter/vector/transaction/ZooKeeperTransactionAllocaterTest.java
+++ b/extensions/adapters/vector/src/test/java/mil/nga/giat/geowave/adapter/vector/transaction/ZooKeeperTransactionAllocaterTest.java
@@ -195,10 +195,10 @@ public class ZooKeeperTransactionAllocaterTest
 						Thread.sleep(200 + (Math.abs(random.nextInt()) % 200));
 					}
 					catch (InterruptedException e) {}
-					allocater.releaseTransaction(txID);
 					synchronized (activeTX) {
 						activeTX.remove(txID);
 					}
+					allocater.releaseTransaction(txID);
 				}
 				catch (Throwable e) {
 					synchronized (failures) {


### PR DESCRIPTION
The new approach also adds an optimization for the use of Interning geometries.  The prior approach lead to excessive memory use due to the reconstitution of geometry PRIOR to interning, creating unnecessary duplicates.