### PR TITLE
Cleaned up unnecessary logging of checked Exception that is handled properly

### DIFF
--- a/extensions/adapters/vector/src/main/java/mil/nga/giat/geowave/adapter/vector/plugin/GeoWaveGTDataStoreFactory.java
+++ b/extensions/adapters/vector/src/main/java/mil/nga/giat/geowave/adapter/vector/plugin/GeoWaveGTDataStoreFactory.java
@@ -134,9 +134,8 @@ public class GeoWaveGTDataStoreFactory implements
 			return true;
 		}
 		catch (GeoWavePluginException e) {
-			LOGGER.error(
-					"Invalid parameters",
-					e);
+			// supplied map does not contain all necessary parameters to
+			// construct GeoWaveGTDataStore
 			return false;
 		}
 	}


### PR DESCRIPTION
Addresses #439 

Issue was an unnecessary LOGGER.error() statement in the catch block of a checked Exception that is actually being handled properly.