### PR TITLE
Implemented a Compound Index Strategy

### DIFF
--- a/core/index/src/main/java/mil/nga/giat/geowave/core/index/CompoundIndexStrategy.java
+++ b/core/index/src/main/java/mil/nga/giat/geowave/core/index/CompoundIndexStrategy.java
@@ -1,0 +1,345 @@
+package mil.nga.giat.geowave.core.index;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import mil.nga.giat.geowave.core.index.dimension.NumericDimensionDefinition;
+import mil.nga.giat.geowave.core.index.sfc.data.BasicNumericDataset;
+import mil.nga.giat.geowave.core.index.sfc.data.MultiDimensionalNumericData;
+import mil.nga.giat.geowave.core.index.sfc.data.NumericData;
+
+public class CompoundIndexStrategy implements
+		NumericIndexStrategy
+{
+
+	private String id;
+	private NumericIndexStrategy subStrategy1;
+	private NumericIndexStrategy subStrategy2;
+	private NumericDimensionDefinition[] baseDefinitions;
+	private int defaultNumberOfRanges;
+
+	public CompoundIndexStrategy(
+			final String id,
+			final NumericIndexStrategy subStrategy1,
+			final NumericIndexStrategy subStrategy2 ) {
+		this.id = id;
+		this.subStrategy1 = subStrategy1;
+		this.subStrategy2 = subStrategy2;
+		baseDefinitions = createNumericDimensionDefinitions();
+		defaultNumberOfRanges = (int) Math.ceil(Math.pow(
+				2,
+				getNumberOfDimensions()));
+	}
+
+	public NumericIndexStrategy[] getSubStrategies() {
+		return new NumericIndexStrategy[] {
+			subStrategy1,
+			subStrategy2
+		};
+	}
+
+	@Override
+	public byte[] toBinary() {
+		final byte[] idBinary = StringUtils.stringToBinary(id);
+		final byte[] delegateBinary1 = PersistenceUtils.toBinary(subStrategy1);
+		final byte[] delegateBinary2 = PersistenceUtils.toBinary(subStrategy2);
+		final ByteBuffer buf = ByteBuffer.allocate(8 + idBinary.length + delegateBinary1.length + delegateBinary2.length);
+		buf.putInt(idBinary.length);
+		buf.put(idBinary);
+		buf.putInt(delegateBinary1.length);
+		buf.put(delegateBinary1);
+		buf.put(delegateBinary2);
+		return buf.array();
+	}
+
+	@Override
+	public void fromBinary(
+			final byte[] bytes ) {
+		final ByteBuffer buf = ByteBuffer.wrap(bytes);
+		final int idBinaryLength = buf.getInt();
+		final byte[] idBinary = new byte[idBinaryLength];
+		buf.get(idBinary);
+		final int delegateBinary1Length = buf.getInt();
+		final byte[] delegateBinary1 = new byte[delegateBinary1Length];
+		buf.get(delegateBinary1);
+		final byte[] delegateBinary2 = new byte[bytes.length - idBinaryLength - delegateBinary1Length - 8];
+		buf.get(delegateBinary2);
+		id = StringUtils.stringFromBinary(idBinary);
+		subStrategy1 = PersistenceUtils.fromBinary(
+				delegateBinary1,
+				NumericIndexStrategy.class);
+		subStrategy2 = PersistenceUtils.fromBinary(
+				delegateBinary2,
+				NumericIndexStrategy.class);
+		baseDefinitions = createNumericDimensionDefinitions();
+		defaultNumberOfRanges = (int) Math.ceil(Math.pow(
+				2,
+				getNumberOfDimensions()));
+	}
+
+	public int[] getNumberOfDimensionsPerIndexStrategy() {
+		return new int[] {
+			subStrategy1.getOrderedDimensionDefinitions().length,
+			subStrategy2.getOrderedDimensionDefinitions().length
+		};
+	}
+
+	public int getNumberOfDimensions() {
+		return baseDefinitions.length;
+	}
+
+	public ByteArrayId composeByteArrayId(
+			final ByteArrayId id1,
+			final ByteArrayId id2 ) {
+		final byte[] bytes = new byte[id1.getBytes().length + id2.getBytes().length + 4];
+		final ByteBuffer buf = ByteBuffer.wrap(bytes);
+		buf.put(id1.getBytes());
+		buf.put(id2.getBytes());
+		buf.putInt(id1.getBytes().length);
+		return new ByteArrayId(
+				bytes);
+	}
+
+	public ByteArrayId[] decomposeByteArrayId(
+			final ByteArrayId id ) {
+		final ByteBuffer buf = ByteBuffer.wrap(id.getBytes());
+		final int id1Length = buf.getInt(id.getBytes().length - 4);
+		final byte[] bytes1 = new byte[id1Length];
+		final byte[] bytes2 = new byte[id.getBytes().length - id1Length - 4];
+		buf.get(bytes1);
+		buf.get(bytes2);
+		return new ByteArrayId[] {
+			new ByteArrayId(
+					bytes1),
+			new ByteArrayId(
+					bytes2)
+		};
+	}
+
+	private List<ByteArrayId> composeByteArrayIds(
+			final List<ByteArrayId> ids1,
+			final List<ByteArrayId> ids2 ) {
+		final List<ByteArrayId> ids = new ArrayList<>(
+				ids1.size() * ids2.size());
+		for (final ByteArrayId id1 : ids1) {
+			for (final ByteArrayId id2 : ids2) {
+				ids.add(composeByteArrayId(
+						id1,
+						id2));
+			}
+		}
+		return ids;
+	}
+
+	private ByteArrayRange composeByteArrayRange(
+			final ByteArrayRange rangeOfStrategy1,
+			final ByteArrayRange rangeOfStrategy2 ) {
+		final ByteArrayId start = composeByteArrayId(
+				rangeOfStrategy1.getStart(),
+				rangeOfStrategy2.getStart());
+		final ByteArrayId end = composeByteArrayId(
+				rangeOfStrategy1.getEnd(),
+				rangeOfStrategy2.getEnd());
+		return new ByteArrayRange(
+				start,
+				end);
+	}
+
+	private List<ByteArrayRange> getByteArrayRanges(
+			final List<ByteArrayRange> ranges1,
+			final List<ByteArrayRange> ranges2 ) {
+		final List<ByteArrayRange> ranges = new ArrayList<>(
+				ranges1.size() + ranges2.size());
+		for (final ByteArrayRange range1 : ranges1) {
+			for (final ByteArrayRange range2 : ranges2) {
+				final ByteArrayRange range = composeByteArrayRange(
+						range1,
+						range2);
+				ranges.add(range);
+			}
+		}
+		return ranges;
+	}
+
+	@Override
+	public List<ByteArrayRange> getQueryRanges(
+			final MultiDimensionalNumericData indexedRange ) {
+		final MultiDimensionalNumericData[] ranges = getRangesForIndexedRange(indexedRange);
+		final List<ByteArrayRange> rangeForStrategy1 = subStrategy1.getQueryRanges(ranges[0]);
+		final List<ByteArrayRange> rangeForStrategy2 = subStrategy2.getQueryRanges(ranges[1]);
+		final List<ByteArrayRange> range = getByteArrayRanges(
+				rangeForStrategy1,
+				rangeForStrategy2);
+		return range;
+	}
+
+	@Override
+	public List<ByteArrayRange> getQueryRanges(
+			final MultiDimensionalNumericData indexedRange,
+			final int maxEstimatedRangeDecomposition ) {
+		final int maxEstRangeDecompositionPerStrategy = (int) Math.ceil(Math.sqrt(maxEstimatedRangeDecomposition));
+		final MultiDimensionalNumericData[] ranges = getRangesForIndexedRange(indexedRange);
+		final List<ByteArrayRange> rangeForStrategy1 = subStrategy1.getQueryRanges(
+				ranges[0],
+				maxEstRangeDecompositionPerStrategy);
+		final List<ByteArrayRange> rangeForStrategy2 = subStrategy2.getQueryRanges(
+				ranges[1],
+				maxEstRangeDecompositionPerStrategy);
+		final List<ByteArrayRange> range = getByteArrayRanges(
+				rangeForStrategy1,
+				rangeForStrategy2);
+		return range;
+	}
+
+	@Override
+	public List<ByteArrayId> getInsertionIds(
+			final MultiDimensionalNumericData indexedData ) {
+		return getInsertionIds(
+				indexedData,
+				defaultNumberOfRanges);
+	}
+
+	@Override
+	public List<ByteArrayId> getInsertionIds(
+			final MultiDimensionalNumericData indexedData,
+			final int maxEstimatedDuplicateIds ) {
+		final int maxEstDuplicatesPerStrategy = (int) Math.ceil(Math.sqrt(maxEstimatedDuplicateIds));
+		final MultiDimensionalNumericData[] ranges = getRangesForIndexedRange(indexedData);
+		final List<ByteArrayId> rangeForStrategy1 = subStrategy1.getInsertionIds(
+				ranges[0],
+				maxEstDuplicatesPerStrategy);
+		final List<ByteArrayId> rangeForStrategy2 = subStrategy2.getInsertionIds(
+				ranges[1],
+				maxEstDuplicatesPerStrategy);
+		final List<ByteArrayId> range = composeByteArrayIds(
+				rangeForStrategy1,
+				rangeForStrategy2);
+		return range;
+	}
+
+	private MultiDimensionalNumericData[] getRangesForId(
+			final ByteArrayId insertionId ) {
+		final ByteArrayId[] insertionIds = decomposeByteArrayId(insertionId);
+		return new MultiDimensionalNumericData[] {
+			subStrategy1.getRangeForId(insertionIds[0]),
+			subStrategy2.getRangeForId(insertionIds[1])
+		};
+	}
+
+	private MultiDimensionalNumericData[] getRangesForIndexedRange(
+			final MultiDimensionalNumericData indexedRange ) {
+		final int[] numDimensionsPerStrategy = getNumberOfDimensionsPerIndexStrategy();
+		final NumericData[] datasets = indexedRange.getDataPerDimension();
+		final NumericData[] datasetForStrategy1 = Arrays.copyOfRange(
+				datasets,
+				0,
+				numDimensionsPerStrategy[0]);
+		final NumericData[] datasetForStrategy2 = Arrays.copyOfRange(
+				datasets,
+				numDimensionsPerStrategy[0],
+				datasets.length);
+		return new MultiDimensionalNumericData[] {
+			new BasicNumericDataset(
+					datasetForStrategy1),
+			new BasicNumericDataset(
+					datasetForStrategy2)
+		};
+	}
+
+	@Override
+	public MultiDimensionalNumericData getRangeForId(
+			final ByteArrayId insertionId ) {
+		final MultiDimensionalNumericData[] rangesForId = getRangesForId(insertionId);
+		final NumericData[] data1 = rangesForId[0].getDataPerDimension();
+		final NumericData[] data2 = rangesForId[1].getDataPerDimension();
+		final NumericData[] dataPerDimension = new NumericData[data1.length + data2.length];
+		System.arraycopy(
+				data1,
+				0,
+				dataPerDimension,
+				0,
+				data1.length);
+		System.arraycopy(
+				data2,
+				0,
+				dataPerDimension,
+				data1.length,
+				data2.length);
+		return new BasicNumericDataset(
+				dataPerDimension);
+	}
+
+	@Override
+	public long[] getCoordinatesPerDimension(
+			final ByteArrayId insertionId ) {
+		final ByteArrayId[] insertionIds = decomposeByteArrayId(insertionId);
+		final long[] coordinates1 = subStrategy1.getCoordinatesPerDimension(insertionIds[0]);
+		final long[] coordinates2 = subStrategy2.getCoordinatesPerDimension(insertionIds[1]);
+		final long[] coordinates = new long[coordinates1.length + coordinates2.length];
+		System.arraycopy(
+				coordinates1,
+				0,
+				coordinates,
+				0,
+				coordinates1.length);
+		System.arraycopy(
+				coordinates2,
+				0,
+				coordinates,
+				coordinates1.length,
+				coordinates2.length);
+		return coordinates;
+	}
+
+	private NumericDimensionDefinition[] createNumericDimensionDefinitions() {
+		final NumericDimensionDefinition[] strategy1Definitions = subStrategy1.getOrderedDimensionDefinitions();
+		final NumericDimensionDefinition[] strategy2Definitions = subStrategy2.getOrderedDimensionDefinitions();
+		final NumericDimensionDefinition[] definitions = new NumericDimensionDefinition[strategy1Definitions.length + strategy2Definitions.length];
+		System.arraycopy(
+				strategy1Definitions,
+				0,
+				definitions,
+				0,
+				strategy1Definitions.length);
+		System.arraycopy(
+				strategy2Definitions,
+				0,
+				definitions,
+				strategy1Definitions.length,
+				strategy2Definitions.length);
+		return definitions;
+	}
+
+	@Override
+	public NumericDimensionDefinition[] getOrderedDimensionDefinitions() {
+		return baseDefinitions;
+	}
+
+	@Override
+	public String getId() {
+		return id;
+	}
+
+	@Override
+	public double[] getHighestPrecisionIdRangePerDimension() {
+		final double[] strategy1HighestPrecision = subStrategy1.getHighestPrecisionIdRangePerDimension();
+		final double[] strategy2HighestPrecision = subStrategy2.getHighestPrecisionIdRangePerDimension();
+		final double[] highestPrecision = new double[strategy1HighestPrecision.length + strategy2HighestPrecision.length];
+		System.arraycopy(
+				strategy1HighestPrecision,
+				0,
+				highestPrecision,
+				0,
+				strategy1HighestPrecision.length);
+		System.arraycopy(
+				strategy2HighestPrecision,
+				0,
+				highestPrecision,
+				strategy1HighestPrecision.length,
+				strategy2HighestPrecision.length);
+		return highestPrecision;
+	}
+
+}

--- a/core/index/src/main/java/mil/nga/giat/geowave/core/index/CompoundIndexStrategy.java
+++ b/core/index/src/main/java/mil/nga/giat/geowave/core/index/CompoundIndexStrategy.java
@@ -10,6 +10,11 @@ import mil.nga.giat.geowave.core.index.sfc.data.BasicNumericDataset;
 import mil.nga.giat.geowave.core.index.sfc.data.MultiDimensionalNumericData;
 import mil.nga.giat.geowave.core.index.sfc.data.NumericData;
 
+/**
+ * Class that implements a compound index strategy. It's a wrapper around two
+ * NumericIndexStrategy objects that can externally be treated as a
+ * multi-dimensional NumericIndexStrategy.
+ */
 public class CompoundIndexStrategy implements
 		NumericIndexStrategy
 {
@@ -79,6 +84,11 @@ public class CompoundIndexStrategy implements
 				getNumberOfDimensions()));
 	}
 
+	/**
+	 * Get the number of dimensions of each sub-strategy
+	 *
+	 * @return an array with the number of dimensions for each sub-strategy
+	 */
 	public int[] getNumberOfDimensionsPerIndexStrategy() {
 		return new int[] {
 			subStrategy1.getOrderedDimensionDefinitions().length,
@@ -86,10 +96,24 @@ public class CompoundIndexStrategy implements
 		};
 	}
 
+	/**
+	 * Get the total number of dimensions from all sub-strategies
+	 *
+	 * @return the number of dimensions
+	 */
 	public int getNumberOfDimensions() {
 		return baseDefinitions.length;
 	}
 
+	/**
+	 * Create a compound ByteArrayId
+	 *
+	 * @param id1
+	 *            ByteArrayId for the first sub-strategy
+	 * @param id2
+	 *            ByteArrayId for the second sub-strategy
+	 * @return the ByteArrayId for the compound strategy
+	 */
 	public ByteArrayId composeByteArrayId(
 			final ByteArrayId id1,
 			final ByteArrayId id2 ) {
@@ -102,6 +126,14 @@ public class CompoundIndexStrategy implements
 				bytes);
 	}
 
+	/**
+	 * Get the ByteArrayId for each sub-strategy from the ByteArrayId for the
+	 * compound index strategy
+	 *
+	 * @param id
+	 *            the compound ByteArrayId
+	 * @return the ByteArrayId for each sub-strategy
+	 */
 	public ByteArrayId[] decomposeByteArrayId(
 			final ByteArrayId id ) {
 		final ByteBuffer buf = ByteBuffer.wrap(id.getBytes());

--- a/core/index/src/test/java/mil/nga/giat/geowave/core/index/CompoundIndexStrategyTest.java
+++ b/core/index/src/test/java/mil/nga/giat/geowave/core/index/CompoundIndexStrategyTest.java
@@ -162,9 +162,10 @@ public class CompoundIndexStrategyTest
 		final List<ByteArrayRange> simpleIndexRanges = simpleIndexStrategy.getQueryRanges(
 				simpleIndexedRange,
 				3);
+		final int maxRangesStrategy2 = 8 / simpleIndexRanges.size();
 		final List<ByteArrayRange> sfcIndexRanges = sfcIndexStrategy.getQueryRanges(
 				sfcIndexedRange,
-				3);
+				maxRangesStrategy2);
 		final List<ByteArrayRange> ranges = new ArrayList<>(
 				simpleIndexRanges.size() * sfcIndexRanges.size());
 		for (final ByteArrayRange r1 : simpleIndexRanges) {
@@ -196,9 +197,10 @@ public class CompoundIndexStrategyTest
 		final List<ByteArrayId> ids1 = simpleIndexStrategy.getInsertionIds(
 				simpleIndexedRange,
 				3);
+		final int maxEstDuplicatesStrategy2 = 8 / ids1.size();
 		final List<ByteArrayId> ids2 = sfcIndexStrategy.getInsertionIds(
 				sfcIndexedRange,
-				3);
+				maxEstDuplicatesStrategy2);
 		for (final ByteArrayId id1 : ids1) {
 			for (final ByteArrayId id2 : ids2) {
 				ids.add(compoundIndexStrategy.composeByteArrayId(
@@ -214,6 +216,38 @@ public class CompoundIndexStrategyTest
 						8));
 		Assert.assertTrue(testIds.containsAll(compoundIndexIds));
 		Assert.assertTrue(compoundIndexIds.containsAll(testIds));
+	}
+
+	@Test
+	public void testGetCoordinatesPerDimension() {
+		final ByteArrayId compoundIndexInsertionId = new ByteArrayId(
+				new byte[] {
+					16,
+					0,
+					-125,
+					16,
+					-46,
+					-93,
+					-110,
+					-31,
+					0,
+					0,
+					0,
+					3
+				});
+		final ByteArrayId[] insertionIds = compoundIndexStrategy.decomposeByteArrayId(compoundIndexInsertionId);
+		final long[] simpleIndexCoordinatesPerDim = simpleIndexStrategy.getCoordinatesPerDimension(insertionIds[0]);
+		final long[] sfcIndexCoordinatesPerDim = sfcIndexStrategy.getCoordinatesPerDimension(insertionIds[1]);
+		final long[] coordinatesPerDim = compoundIndexStrategy.getCoordinatesPerDimension(compoundIndexInsertionId);
+		Assert.assertTrue(Double.compare(
+				simpleIndexCoordinatesPerDim[0],
+				coordinatesPerDim[0]) == 0);
+		Assert.assertTrue(Double.compare(
+				sfcIndexCoordinatesPerDim[0],
+				coordinatesPerDim[1]) == 0);
+		Assert.assertTrue(Double.compare(
+				sfcIndexCoordinatesPerDim[1],
+				coordinatesPerDim[2]) == 0);
 	}
 
 	@Test
@@ -264,38 +298,6 @@ public class CompoundIndexStrategyTest
 		Assert.assertTrue(Double.compare(
 				sfcIndexRange.getMaxValuesPerDimension()[1],
 				range.getMaxValuesPerDimension()[2]) == 0);
-	}
-
-	@Test
-	public void testGetCoordinatesPerDimension() {
-		final ByteArrayId compoundIndexInsertionId = new ByteArrayId(
-				new byte[] {
-					16,
-					0,
-					-125,
-					16,
-					-46,
-					-93,
-					-110,
-					-31,
-					0,
-					0,
-					0,
-					3
-				});
-		final ByteArrayId[] insertionIds = compoundIndexStrategy.decomposeByteArrayId(compoundIndexInsertionId);
-		final long[] simpleIndexCoordinatesPerDim = simpleIndexStrategy.getCoordinatesPerDimension(insertionIds[0]);
-		final long[] sfcIndexCoordinatesPerDim = sfcIndexStrategy.getCoordinatesPerDimension(insertionIds[1]);
-		final long[] coordinatesPerDim = compoundIndexStrategy.getCoordinatesPerDimension(compoundIndexInsertionId);
-		Assert.assertTrue(Double.compare(
-				simpleIndexCoordinatesPerDim[0],
-				coordinatesPerDim[0]) == 0);
-		Assert.assertTrue(Double.compare(
-				sfcIndexCoordinatesPerDim[0],
-				coordinatesPerDim[1]) == 0);
-		Assert.assertTrue(Double.compare(
-				sfcIndexCoordinatesPerDim[1],
-				coordinatesPerDim[2]) == 0);
 	}
 
 	@Test

--- a/core/index/src/test/java/mil/nga/giat/geowave/core/index/CompoundIndexStrategyTest.java
+++ b/core/index/src/test/java/mil/nga/giat/geowave/core/index/CompoundIndexStrategyTest.java
@@ -1,0 +1,316 @@
+package mil.nga.giat.geowave.core.index;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import mil.nga.giat.geowave.core.index.dimension.BasicDimensionDefinition;
+import mil.nga.giat.geowave.core.index.dimension.NumericDimensionDefinition;
+import mil.nga.giat.geowave.core.index.sfc.SFCFactory.SFCType;
+import mil.nga.giat.geowave.core.index.sfc.data.BasicNumericDataset;
+import mil.nga.giat.geowave.core.index.sfc.data.MultiDimensionalNumericData;
+import mil.nga.giat.geowave.core.index.sfc.data.NumericData;
+import mil.nga.giat.geowave.core.index.sfc.data.NumericRange;
+import mil.nga.giat.geowave.core.index.sfc.tiered.TieredSFCIndexFactory;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class CompoundIndexStrategyTest
+{
+
+	private static final NumericDimensionDefinition[] DIMENSIONS = new NumericDimensionDefinition[] {
+		new BasicDimensionDefinition(
+				0,
+				1000)
+	};
+
+	private static final NumericIndexStrategy simpleIndexStrategy = TieredSFCIndexFactory.createSingleTierStrategy(
+			DIMENSIONS,
+			new int[] {
+				16
+			},
+			SFCType.HILBERT);
+
+	private static final NumericDimensionDefinition[] SPATIAL_DIMENSIONS = new NumericDimensionDefinition[] {
+		new BasicDimensionDefinition(
+				-180,
+				180),
+		new BasicDimensionDefinition(
+				-90,
+				90)
+	};
+
+	private static final NumericIndexStrategy sfcIndexStrategy = TieredSFCIndexFactory.createSingleTierStrategy(
+			SPATIAL_DIMENSIONS,
+			new int[] {
+				16,
+				16
+			},
+			SFCType.HILBERT);
+
+	private static final CompoundIndexStrategy compoundIndexStrategy = new CompoundIndexStrategy(
+			"compound_idx",
+			simpleIndexStrategy,
+			sfcIndexStrategy);
+
+	private static final NumericRange dimension1Range = new NumericRange(
+			2,
+			4);
+	private static final NumericRange dimension2Range = new NumericRange(
+			50.0,
+			50.025);
+	private static final NumericRange dimension3Range = new NumericRange(
+			-20.5,
+			-20.455);
+	private static final MultiDimensionalNumericData simpleIndexedRange = new BasicNumericDataset(
+			new NumericData[] {
+				dimension1Range,
+			});
+	private static final MultiDimensionalNumericData sfcIndexedRange = new BasicNumericDataset(
+			new NumericData[] {
+				dimension2Range,
+				dimension3Range
+			});
+	private static final MultiDimensionalNumericData compoundIndexedRange = new BasicNumericDataset(
+			new NumericData[] {
+				dimension1Range,
+				dimension2Range,
+				dimension3Range
+			});
+
+	@Test
+	public void testBinaryEncoding() {
+		final byte[] bytes = compoundIndexStrategy.toBinary();
+		final CompoundIndexStrategy deserializedStrategy = new CompoundIndexStrategy(
+				null,
+				new NullNumericIndexStrategy(),
+				new NullNumericIndexStrategy());
+		deserializedStrategy.fromBinary(bytes);
+		final byte[] bytes2 = deserializedStrategy.toBinary();
+		Assert.assertArrayEquals(
+				bytes,
+				bytes2);
+	}
+
+	@Test
+	public void testNumberOfDimensionsPerIndexStrategy() {
+		final int[] numDimensionsPerStrategy = compoundIndexStrategy.getNumberOfDimensionsPerIndexStrategy();
+		Assert.assertEquals(
+				1,
+				numDimensionsPerStrategy[0]);
+		Assert.assertEquals(
+				2,
+				numDimensionsPerStrategy[1]);
+	}
+
+	@Test
+	public void testGetNumberOfDimensions() {
+		final int numDimensions = compoundIndexStrategy.getNumberOfDimensions();
+		Assert.assertEquals(
+				3,
+				numDimensions);
+	}
+
+	@Test
+	public void testCompositionOfByteArrayId() {
+		final ByteArrayId id1 = new ByteArrayId(
+				"hello");
+		final ByteArrayId id2 = new ByteArrayId(
+				"world!!");
+		final ByteArrayId compoundId = compoundIndexStrategy.composeByteArrayId(
+				id1,
+				id2);
+		final ByteArrayId[] decomposedId = compoundIndexStrategy.decomposeByteArrayId(compoundId);
+		Assert.assertArrayEquals(
+				id1.getBytes(),
+				decomposedId[0].getBytes());
+		Assert.assertArrayEquals(
+				id2.getBytes(),
+				decomposedId[1].getBytes());
+	}
+
+	@Test
+	public void testGetQueryRangesWithMaximumNumberOfRanges() {
+		final List<ByteArrayRange> simpleIndexRanges = simpleIndexStrategy.getQueryRanges(simpleIndexedRange);
+		final List<ByteArrayRange> sfcIndexRanges = sfcIndexStrategy.getQueryRanges(sfcIndexedRange);
+		final List<ByteArrayRange> ranges = new ArrayList<>();
+		for (final ByteArrayRange r1 : simpleIndexRanges) {
+			for (final ByteArrayRange r2 : sfcIndexRanges) {
+				final ByteArrayId start = compoundIndexStrategy.composeByteArrayId(
+						r1.getStart(),
+						r2.getStart());
+				final ByteArrayId end = compoundIndexStrategy.composeByteArrayId(
+						r1.getEnd(),
+						r2.getEnd());
+				ranges.add(new ByteArrayRange(
+						start,
+						end));
+			}
+		}
+		final Set<ByteArrayRange> testRanges = new HashSet<>(
+				ranges);
+		final Set<ByteArrayRange> compoundIndexRanges = new HashSet<>(
+				compoundIndexStrategy.getQueryRanges(compoundIndexedRange));
+		Assert.assertTrue(testRanges.containsAll(compoundIndexRanges));
+		Assert.assertTrue(compoundIndexRanges.containsAll(testRanges));
+	}
+
+	@Test
+	public void testGetQueryRanges() {
+		final List<ByteArrayRange> simpleIndexRanges = simpleIndexStrategy.getQueryRanges(
+				simpleIndexedRange,
+				3);
+		final List<ByteArrayRange> sfcIndexRanges = sfcIndexStrategy.getQueryRanges(
+				sfcIndexedRange,
+				3);
+		final List<ByteArrayRange> ranges = new ArrayList<>(
+				simpleIndexRanges.size() * sfcIndexRanges.size());
+		for (final ByteArrayRange r1 : simpleIndexRanges) {
+			for (final ByteArrayRange r2 : sfcIndexRanges) {
+				final ByteArrayId start = compoundIndexStrategy.composeByteArrayId(
+						r1.getStart(),
+						r2.getStart());
+				final ByteArrayId end = compoundIndexStrategy.composeByteArrayId(
+						r1.getEnd(),
+						r2.getEnd());
+				ranges.add(new ByteArrayRange(
+						start,
+						end));
+			}
+		}
+		final Set<ByteArrayRange> testRanges = new HashSet<>(
+				ranges);
+		final Set<ByteArrayRange> compoundIndexRanges = new HashSet<>(
+				compoundIndexStrategy.getQueryRanges(
+						compoundIndexedRange,
+						8));
+		Assert.assertTrue(testRanges.containsAll(compoundIndexRanges));
+		Assert.assertTrue(compoundIndexRanges.containsAll(testRanges));
+	}
+
+	@Test
+	public void testGetInsertionIds() {
+		final List<ByteArrayId> ids = new ArrayList<>();
+		final List<ByteArrayId> ids1 = simpleIndexStrategy.getInsertionIds(
+				simpleIndexedRange,
+				3);
+		final List<ByteArrayId> ids2 = sfcIndexStrategy.getInsertionIds(
+				sfcIndexedRange,
+				3);
+		for (final ByteArrayId id1 : ids1) {
+			for (final ByteArrayId id2 : ids2) {
+				ids.add(compoundIndexStrategy.composeByteArrayId(
+						id1,
+						id2));
+			}
+		}
+		final Set<ByteArrayId> testIds = new HashSet<>(
+				ids);
+		final Set<ByteArrayId> compoundIndexIds = new HashSet<>(
+				compoundIndexStrategy.getInsertionIds(
+						compoundIndexedRange,
+						8));
+		Assert.assertTrue(testIds.containsAll(compoundIndexIds));
+		Assert.assertTrue(compoundIndexIds.containsAll(testIds));
+	}
+
+	@Test
+	public void testGetRangeForId() {
+		final ByteArrayId compoundIndexInsertionId = new ByteArrayId(
+				new byte[] {
+					16,
+					0,
+					-125,
+					16,
+					-46,
+					-93,
+					-110,
+					-31,
+					0,
+					0,
+					0,
+					3
+				});
+		final ByteArrayId[] insertionIds = compoundIndexStrategy.decomposeByteArrayId(compoundIndexInsertionId);
+		final MultiDimensionalNumericData simpleIndexRange = simpleIndexStrategy.getRangeForId(insertionIds[0]);
+		final MultiDimensionalNumericData sfcIndexRange = sfcIndexStrategy.getRangeForId(insertionIds[1]);
+		final MultiDimensionalNumericData range = compoundIndexStrategy.getRangeForId(compoundIndexInsertionId);
+		Assert.assertEquals(
+				simpleIndexRange.getDimensionCount(),
+				1);
+		Assert.assertEquals(
+				sfcIndexRange.getDimensionCount(),
+				2);
+		Assert.assertEquals(
+				range.getDimensionCount(),
+				3);
+		Assert.assertTrue(Double.compare(
+				simpleIndexRange.getMinValuesPerDimension()[0],
+				range.getMinValuesPerDimension()[0]) == 0);
+		Assert.assertTrue(Double.compare(
+				sfcIndexRange.getMinValuesPerDimension()[0],
+				range.getMinValuesPerDimension()[1]) == 0);
+		Assert.assertTrue(Double.compare(
+				sfcIndexRange.getMinValuesPerDimension()[1],
+				range.getMinValuesPerDimension()[2]) == 0);
+		Assert.assertTrue(Double.compare(
+				simpleIndexRange.getMaxValuesPerDimension()[0],
+				range.getMaxValuesPerDimension()[0]) == 0);
+		Assert.assertTrue(Double.compare(
+				sfcIndexRange.getMaxValuesPerDimension()[0],
+				range.getMaxValuesPerDimension()[1]) == 0);
+		Assert.assertTrue(Double.compare(
+				sfcIndexRange.getMaxValuesPerDimension()[1],
+				range.getMaxValuesPerDimension()[2]) == 0);
+	}
+
+	@Test
+	public void testGetCoordinatesPerDimension() {
+		final ByteArrayId compoundIndexInsertionId = new ByteArrayId(
+				new byte[] {
+					16,
+					0,
+					-125,
+					16,
+					-46,
+					-93,
+					-110,
+					-31,
+					0,
+					0,
+					0,
+					3
+				});
+		final ByteArrayId[] insertionIds = compoundIndexStrategy.decomposeByteArrayId(compoundIndexInsertionId);
+		final long[] simpleIndexCoordinatesPerDim = simpleIndexStrategy.getCoordinatesPerDimension(insertionIds[0]);
+		final long[] sfcIndexCoordinatesPerDim = sfcIndexStrategy.getCoordinatesPerDimension(insertionIds[1]);
+		final long[] coordinatesPerDim = compoundIndexStrategy.getCoordinatesPerDimension(compoundIndexInsertionId);
+		Assert.assertTrue(Double.compare(
+				simpleIndexCoordinatesPerDim[0],
+				coordinatesPerDim[0]) == 0);
+		Assert.assertTrue(Double.compare(
+				sfcIndexCoordinatesPerDim[0],
+				coordinatesPerDim[1]) == 0);
+		Assert.assertTrue(Double.compare(
+				sfcIndexCoordinatesPerDim[1],
+				coordinatesPerDim[2]) == 0);
+	}
+
+	@Test
+	public void testGetHighestPrecisionIdRangePerDimension() {
+		final double[] simpleIndexPrecision = simpleIndexStrategy.getHighestPrecisionIdRangePerDimension();
+		final double[] sfcIndexPrecision = sfcIndexStrategy.getHighestPrecisionIdRangePerDimension();
+		final double[] precisionPerDim = compoundIndexStrategy.getHighestPrecisionIdRangePerDimension();
+		Assert.assertTrue(Double.compare(
+				precisionPerDim[0],
+				simpleIndexPrecision[0]) == 0);
+		Assert.assertTrue(Double.compare(
+				precisionPerDim[1],
+				sfcIndexPrecision[0]) == 0);
+		Assert.assertTrue(Double.compare(
+				precisionPerDim[2],
+				sfcIndexPrecision[1]) == 0);
+	}
+}


### PR DESCRIPTION
Implemented CompoundIndexStrategy. For now it allows the
composition of two NumericIndexStrategy objects into a
single NumericIndexStrategy. This can easily be modified
to support N sub-indeces. The dimensions of the
CompoundIndexStrategy are the sum of the dimensions of
the sub-indeces. The compound index prefixes the bytes
from the first sub-index before any of the bytes from the
second. Externally, the compound index can be treated like
any other multi-dimensional index.