### PR TITLE
Issue #448. GPX Consumer is not freeing up temporary objects created …

### DIFF
--- a/extensions/formats/gpx/src/main/java/mil/nga/giat/geowave/format/gpx/GPXConsumer.java
+++ b/extensions/formats/gpx/src/main/java/mil/nga/giat/geowave/format/gpx/GPXConsumer.java
@@ -233,6 +233,9 @@ public class GPXConsumer implements
 					currentElement = currentElementStack.peek();
 					// currentElement.removeChild(child);
 				}
+				else if (currentElementStack.size() == 1) {
+					top.children.remove(child);
+				}
 			}
 		}
 		return newFeature;
@@ -469,6 +472,7 @@ public class GPXConsumer implements
 		List<GPXDataElement> children = null;
 		GPXDataElement parent;
 		long id = 0;
+		int childIdCounter = 0;
 
 		public GPXDataElement(
 				final String myElType ) {
@@ -504,7 +508,7 @@ public class GPXConsumer implements
 			}
 			children.add(child);
 			child.parent = this;
-			child.id = children.size();
+			child.id = ++childIdCounter;
 		}
 
 		public String composeID(
@@ -786,7 +790,7 @@ public class GPXConsumer implements
 							inputID.length() > 0 ? inputID : element.composeID(
 									"",
 									false,
-									true));
+									true));					
 					return buildGeoWaveDataInstance(
 							element.composeID(
 									inputID,

--- a/extensions/formats/gpx/src/main/java/mil/nga/giat/geowave/format/gpx/GpxIngestPlugin.java
+++ b/extensions/formats/gpx/src/main/java/mil/nga/giat/geowave/format/gpx/GpxIngestPlugin.java
@@ -21,7 +21,6 @@ import mil.nga.giat.geowave.core.geotime.IndexType;
 import mil.nga.giat.geowave.core.index.ByteArrayId;
 import mil.nga.giat.geowave.core.ingest.GeoWaveData;
 import mil.nga.giat.geowave.core.ingest.IngestPluginBase;
-import mil.nga.giat.geowave.core.ingest.avro.GenericAvroSerializer;
 import mil.nga.giat.geowave.core.ingest.hdfs.mapreduce.IngestWithMapper;
 import mil.nga.giat.geowave.core.ingest.hdfs.mapreduce.IngestWithReducer;
 import mil.nga.giat.geowave.core.store.CloseableIterator;

--- a/extensions/formats/gpx/src/test/java/mil/nga/giat/geowave/types/gpx/GPXConsumerTest.java
+++ b/extensions/formats/gpx/src/test/java/mil/nga/giat/geowave/types/gpx/GPXConsumerTest.java
@@ -186,7 +186,9 @@ public class GPXConsumerTest
 
 		while (consumer.hasNext()) {
 			GeoWaveData<SimpleFeature> data = consumer.next();
-			expectedSet.remove(data.getValue().getID());
+			if (!expectedSet.remove(data.getValue().getID())) {
+				System.out.println("Missing match:" + data.getValue().getID());
+			}
 			ValidateObject<SimpleFeature> tester = expectedResults.get(data.getValue().getID());
 			if (tester != null) {
 				assertTrue(


### PR DESCRIPTION
…during file processing until the entire file is consumed