### PR TITLE
Geowave 464

### DIFF
--- a/core/ingest/src/main/java/mil/nga/giat/geowave/core/ingest/AbstractIngestCommandLineDriver.java
+++ b/core/ingest/src/main/java/mil/nga/giat/geowave/core/ingest/AbstractIngestCommandLineDriver.java
@@ -107,7 +107,8 @@ abstract public class AbstractIngestCommandLineDriver implements
 		try {
 			CommandLine commandLine = parser.parse(
 					options,
-					args);
+					args,
+					true);
 			if (commandLine.hasOption("h")) {
 				printHelp(
 						options,
@@ -138,9 +139,7 @@ abstract public class AbstractIngestCommandLineDriver implements
 			}
 			else if (commandLine.hasOption("f")) {
 				try {
-					selectedPluginProviders = getPluginProviders(
-							commandLine,
-							options);
+					selectedPluginProviders = getPluginProviders(commandLine);
 				}
 				catch (final Exception e) {
 					LOGGER.fatal(
@@ -154,6 +153,12 @@ abstract public class AbstractIngestCommandLineDriver implements
 				if (selectedPluginProviders.isEmpty()) {
 					LOGGER.fatal("There were no ingest format plugin providers found");
 					System.exit(-3);
+				}
+			}
+			for (final IngestFormatPluginProviderSpi<?, ?> plugin : selectedPluginProviders) {
+				final IngestFormatOptionProvider optionProvider = plugin.getIngestFormatOptionProvider();
+				if (optionProvider != null) {
+					optionProvider.applyOptions(options);
 				}
 			}
 			if (options.getOptions().size() > optionCount) {
@@ -184,8 +189,7 @@ abstract public class AbstractIngestCommandLineDriver implements
 	}
 
 	private List<IngestFormatPluginProviderSpi<?, ?>> getPluginProviders(
-			final CommandLine commandLine,
-			final Options options ) {
+			final CommandLine commandLine ) {
 		final List<IngestFormatPluginProviderSpi<?, ?>> selectedPluginProviders = new ArrayList<IngestFormatPluginProviderSpi<?, ?>>();
 		final String[] pluginProviderNames = commandLine.getOptionValue(
 				"f").split(
@@ -201,12 +205,6 @@ abstract public class AbstractIngestCommandLineDriver implements
 		if (selectedPluginProviders.isEmpty()) {
 			throw new IllegalArgumentException(
 					"There were no ingest format plugin providers found");
-		}
-		for (final IngestFormatPluginProviderSpi<?, ?> plugin : selectedPluginProviders) {
-			final IngestFormatOptionProvider optionProvider = plugin.getIngestFormatOptionProvider();
-			if (optionProvider != null) {
-				optionProvider.applyOptions(options);
-			}
 		}
 		return selectedPluginProviders;
 	}


### PR DESCRIPTION
Per @ewilson-radblue:

Addresses #464 (I suppose creating that issue wasn't necessary).

The problem was when using fields specified in an IngestFormatOptionProvider from a plugin. In AbstractIngestCommandLineDriver, it tries to parse the command on line 108 but does not call IngestFormatOptionProvider's applyOptions() method until it calls getPluginProviders() on line 141. It would try to reparse the command on line 162 with the additional options, but the failed parse on line 108 throws an exception and never gets to that line. Also, if the 'f' flag is not specified, the custom options are never added at all.

The fix is to set the parameter 'stopAtNonOption' to 'true' for CommandLineParser.parse() so that it doesn't throw an exception on an unrecognized parameter. This allows it to pull out the 'f' flag value and apply the flags for the appropriate plugins. Also, moved the application of the plugins' custom parameters to apply even in cases where the 'f' flag is not specified.