### PR TITLE
Implemented a Simple NumericIndexStrategy

### DIFF
--- a/core/index/src/main/java/mil/nga/giat/geowave/core/index/lexicoder/IntegerLexicoder.java
+++ b/core/index/src/main/java/mil/nga/giat/geowave/core/index/lexicoder/IntegerLexicoder.java
@@ -1,0 +1,45 @@
+package mil.nga.giat.geowave.core.index.lexicoder;
+
+import com.google.common.primitives.Ints;
+
+/**
+ * A lexicoder for signed integers (in the range from Integer.MIN_VALUE to
+ * Integer.MAX_VALUE). Does an exclusive or on the most significant bit to
+ * invert the sign, so that lexicographic ordering of the byte arrays matches
+ * the natural order of the numbers.
+ *
+ * See Apache Accumulo
+ * (org.apache.accumulo.core.client.lexicoder.IntegerLexicoder)
+ */
+public class IntegerLexicoder implements
+		NumberLexicoder<Integer>
+{
+
+	protected IntegerLexicoder() {}
+
+	@Override
+	public byte[] toByteArray(
+			final Integer value ) {
+		return Ints.toByteArray(
+				value ^ 0x80000000);
+	}
+
+	@Override
+	public Integer fromByteArray(
+			final byte[] bytes ) {
+		final int value = Ints.fromByteArray(
+				bytes);
+		return value ^ 0x80000000;
+	}
+
+	@Override
+	public Integer getMinimumValue() {
+		return Integer.MIN_VALUE;
+	}
+
+	@Override
+	public Integer getMaximumValue() {
+		return Integer.MAX_VALUE;
+	}
+
+}

--- a/core/index/src/main/java/mil/nga/giat/geowave/core/index/lexicoder/Lexicoders.java
+++ b/core/index/src/main/java/mil/nga/giat/geowave/core/index/lexicoder/Lexicoders.java
@@ -1,0 +1,12 @@
+package mil.nga.giat.geowave.core.index.lexicoder;
+
+/**
+ * A class containing instances of lexicoders.
+ *
+ */
+public class Lexicoders
+{
+	public static final ShortLexicoder SHORT = new ShortLexicoder();
+	public static final IntegerLexicoder INT = new IntegerLexicoder();
+	public static final LongLexicoder LONG = new LongLexicoder();
+}

--- a/core/index/src/main/java/mil/nga/giat/geowave/core/index/lexicoder/LongLexicoder.java
+++ b/core/index/src/main/java/mil/nga/giat/geowave/core/index/lexicoder/LongLexicoder.java
@@ -1,0 +1,44 @@
+package mil.nga.giat.geowave.core.index.lexicoder;
+
+import com.google.common.primitives.Longs;
+
+/**
+ * A lexicoder for signed integers (in the range from Long.MIN_VALUE to
+ * Long.MAX_VALUE). Does an exclusive or on the most significant bit to invert
+ * the sign, so that lexicographic ordering of the byte arrays matches the
+ * natural order of the numbers.
+ *
+ * See Apache Accumulo (org.apache.accumulo.core.client.lexicoder.LongLexicoder)
+ */
+public class LongLexicoder implements
+		NumberLexicoder<Long>
+{
+
+	protected LongLexicoder() {}
+
+	@Override
+	public byte[] toByteArray(
+			final Long value ) {
+		return Longs.toByteArray(
+				value ^ 0x8000000000000000l);
+	}
+
+	@Override
+	public Long fromByteArray(
+			final byte[] bytes ) {
+		final long value = Longs.fromByteArray(
+				bytes);
+		return value ^ 0x8000000000000000l;
+	}
+
+	@Override
+	public Long getMinimumValue() {
+		return Long.MIN_VALUE;
+	}
+
+	@Override
+	public Long getMaximumValue() {
+		return Long.MAX_VALUE;
+	}
+
+}

--- a/core/index/src/main/java/mil/nga/giat/geowave/core/index/lexicoder/NumberLexicoder.java
+++ b/core/index/src/main/java/mil/nga/giat/geowave/core/index/lexicoder/NumberLexicoder.java
@@ -1,0 +1,48 @@
+package mil.nga.giat.geowave.core.index.lexicoder;
+
+/**
+ * A lexicoder for a number type. Converts back and forth between a number and a
+ * byte array. A lexicographical sorting of the byte arrays will yield the
+ * natural order of the numbers that they represent.
+ *
+ * @param <T>
+ *            a number type
+ */
+public interface NumberLexicoder<T extends Number>
+{
+	/**
+	 * Get a byte[] that represents the number value.
+	 *
+	 * @param value
+	 *            a number
+	 * @return the byte array representing the number
+	 */
+	public byte[] toByteArray(
+			T value );
+
+	/**
+	 * Get the value of a byte array
+	 *
+	 * @param bytes
+	 *            a byte array representing a number
+	 * @return the number
+	 */
+	public T fromByteArray(
+			byte[] bytes );
+
+	/**
+	 * Get the minimum value of the range of numbers that this lexicoder can
+	 * encode and decode (i.e. the number represented by all 0 bits).
+	 *
+	 * @return the minimum value in the lexicoder's range
+	 */
+	public T getMinimumValue();
+
+	/**
+	 * Get the maximum value of the range of numbers that this lexicoder can
+	 * encode and decode (i.e. the number represented by all 1 bits).
+	 *
+	 * @return the maximum value in the lexicoder's range
+	 */
+	public T getMaximumValue();
+}

--- a/core/index/src/main/java/mil/nga/giat/geowave/core/index/lexicoder/ShortLexicoder.java
+++ b/core/index/src/main/java/mil/nga/giat/geowave/core/index/lexicoder/ShortLexicoder.java
@@ -1,0 +1,43 @@
+package mil.nga.giat.geowave.core.index.lexicoder;
+
+import com.google.common.primitives.Shorts;
+
+/**
+ * A lexicoder for signed integers (in the range from Short.MIN_VALUE to
+ * Short.MAX_VALUE). Does an exclusive or on the most significant bit to invert
+ * the sign, so that lexicographic ordering of the byte arrays matches the
+ * natural order of the numbers.
+ *
+ */
+public class ShortLexicoder implements
+		NumberLexicoder<Short>
+{
+
+	protected ShortLexicoder() {}
+
+	@Override
+	public byte[] toByteArray(
+			final Short value ) {
+		return Shorts.toByteArray(
+				(short) (value ^ 0x8000));
+	}
+
+	@Override
+	public Short fromByteArray(
+			final byte[] bytes ) {
+		final short value = Shorts.fromByteArray(
+				bytes);
+		return (short) (value ^ 0x8000);
+	}
+
+	@Override
+	public Short getMinimumValue() {
+		return Short.MIN_VALUE;
+	}
+
+	@Override
+	public Short getMaximumValue() {
+		return Short.MAX_VALUE;
+	}
+
+}

--- a/core/index/src/main/java/mil/nga/giat/geowave/core/index/simple/SimpleIntegerIndexStrategy.java
+++ b/core/index/src/main/java/mil/nga/giat/geowave/core/index/simple/SimpleIntegerIndexStrategy.java
@@ -1,0 +1,36 @@
+package mil.nga.giat.geowave.core.index.simple;
+
+import mil.nga.giat.geowave.core.index.lexicoder.Lexicoders;
+
+/**
+ * A simple 1-dimensional NumericIndexStrategy that represents an index of
+ * signed integer values. The strategy doesn't use any binning. The ids are
+ * simply the byte arrays of the value. This index strategy will not perform
+ * well for inserting ranges because there will be too much replication of data.
+ *
+ */
+public class SimpleIntegerIndexStrategy extends
+		SimpleNumericIndexStrategy<Integer>
+{
+
+	public SimpleIntegerIndexStrategy() {
+		super(
+				Lexicoders.INT);
+	}
+
+	@Override
+	public byte[] toBinary() {
+		return new byte[] {};
+	}
+
+	@Override
+	public void fromBinary(
+			final byte[] bytes ) {}
+
+	@Override
+	protected Integer cast(
+			final double value ) {
+		return (int) value;
+	}
+
+}

--- a/core/index/src/main/java/mil/nga/giat/geowave/core/index/simple/SimpleLongIndexStrategy.java
+++ b/core/index/src/main/java/mil/nga/giat/geowave/core/index/simple/SimpleLongIndexStrategy.java
@@ -1,0 +1,36 @@
+package mil.nga.giat.geowave.core.index.simple;
+
+import mil.nga.giat.geowave.core.index.lexicoder.Lexicoders;
+
+/**
+ * A simple 1-dimensional NumericIndexStrategy that represents an index of
+ * signed long values. The strategy doesn't use any binning. The ids are simply
+ * the byte arrays of the value. This index strategy will not perform well for
+ * inserting ranges because there will be too much replication of data.
+ *
+ */
+public class SimpleLongIndexStrategy extends
+		SimpleNumericIndexStrategy<Long>
+{
+
+	public SimpleLongIndexStrategy() {
+		super(
+				Lexicoders.LONG);
+	}
+
+	@Override
+	public byte[] toBinary() {
+		return new byte[] {};
+	}
+
+	@Override
+	public void fromBinary(
+			final byte[] bytes ) {}
+
+	@Override
+	protected Long cast(
+			final double value ) {
+		return (long) value;
+	}
+
+}

--- a/core/index/src/main/java/mil/nga/giat/geowave/core/index/simple/SimpleNumericIndexStrategy.java
+++ b/core/index/src/main/java/mil/nga/giat/geowave/core/index/simple/SimpleNumericIndexStrategy.java
@@ -1,0 +1,185 @@
+package mil.nga.giat.geowave.core.index.simple;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import mil.nga.giat.geowave.core.index.ByteArrayId;
+import mil.nga.giat.geowave.core.index.ByteArrayRange;
+import mil.nga.giat.geowave.core.index.NumericIndexStrategy;
+import mil.nga.giat.geowave.core.index.StringUtils;
+import mil.nga.giat.geowave.core.index.dimension.BasicDimensionDefinition;
+import mil.nga.giat.geowave.core.index.dimension.NumericDimensionDefinition;
+import mil.nga.giat.geowave.core.index.lexicoder.NumberLexicoder;
+import mil.nga.giat.geowave.core.index.sfc.data.BasicNumericDataset;
+import mil.nga.giat.geowave.core.index.sfc.data.MultiDimensionalNumericData;
+import mil.nga.giat.geowave.core.index.sfc.data.NumericData;
+import mil.nga.giat.geowave.core.index.sfc.data.NumericValue;
+
+/**
+ * A simple 1-dimensional NumericIndexStrategy that represents an index of
+ * signed integer values (currently supports 16 bit, 32 bit, and 64 bit
+ * integers). The strategy doesn't use any binning. The ids are simply the byte
+ * arrays of the value. This index strategy will not perform well for inserting
+ * ranges because there will be too much replication of data.
+ *
+ */
+public abstract class SimpleNumericIndexStrategy<T extends Number> implements
+		NumericIndexStrategy
+{
+
+	private final NumberLexicoder<T> lexicoder;
+	private final NumericDimensionDefinition[] definitions;
+
+	protected SimpleNumericIndexStrategy(
+			final NumberLexicoder<T> lexicoder ) {
+		this.lexicoder = lexicoder;
+		this.definitions = new NumericDimensionDefinition[] {
+			new BasicDimensionDefinition(
+					lexicoder.getMinimumValue().doubleValue(),
+					lexicoder.getMaximumValue().doubleValue())
+		};
+	}
+
+	protected NumberLexicoder<T> getLexicoder() {
+		return lexicoder;
+	}
+
+	/**
+	 * Cast a double into the type T
+	 *
+	 * @param value
+	 *            a double value
+	 * @return the value represented as a T
+	 */
+	protected abstract T cast(
+			double value );
+
+	/**
+	 * Always returns a single range since this is a 1-dimensional index. The
+	 * sort-order of the bytes is the same as the sort order of values, so an
+	 * indexedRange can be represented by a single contiguous ByteArrayRange.
+	 * {@inheritDoc}
+	 */
+	@Override
+	public List<ByteArrayRange> getQueryRanges(
+			final MultiDimensionalNumericData indexedRange ) {
+		return getQueryRanges(
+				indexedRange,
+				-1);
+	}
+
+	/**
+	 * Always returns a single range since this is a 1-dimensional index. The
+	 * sort-order of the bytes is the same as the sort order of values, so an
+	 * indexedRange can be represented by a single contiguous ByteArrayRange.
+	 * {@inheritDoc}
+	 */
+	@Override
+	public List<ByteArrayRange> getQueryRanges(
+			final MultiDimensionalNumericData indexedRange,
+			final int maxEstimatedRangeDecomposition ) {
+		final T min = cast(
+				indexedRange.getMinValuesPerDimension()[0]);
+		final ByteArrayId start = new ByteArrayId(
+				lexicoder.toByteArray(
+						min));
+		final T max = cast(
+				Math.ceil(
+						indexedRange.getMaxValuesPerDimension()[0]));
+		final ByteArrayId end = new ByteArrayId(
+				lexicoder.toByteArray(
+						max));
+		final ByteArrayRange range = new ByteArrayRange(
+				start,
+				end);
+		return Collections.singletonList(
+				range);
+	}
+
+	/**
+	 * Returns all of the insertion ids for the range. Since this index strategy
+	 * doensn't use binning, it will return the ByteArrayId of every value in
+	 * the range (i.e. if you are storing a range using this index strategy,
+	 * your data will be replicated for every integer value in the range).
+	 *
+	 * {@inheritDoc}
+	 */
+	@Override
+	public List<ByteArrayId> getInsertionIds(
+			final MultiDimensionalNumericData indexedData ) {
+		return getInsertionIds(
+				indexedData,
+				-1);
+	}
+
+	/**
+	 * Returns all of the insertion ids for the range. Since this index strategy
+	 * doensn't use binning, it will return the ByteArrayId of every value in
+	 * the range (i.e. if you are storing a range using this index strategy,
+	 * your data will be replicated for every integer value in the range).
+	 *
+	 * {@inheritDoc}
+	 */
+	@Override
+	public List<ByteArrayId> getInsertionIds(
+			final MultiDimensionalNumericData indexedData,
+			final int maxEstimatedDuplicateIds ) {
+		final long min = (long) indexedData.getMinValuesPerDimension()[0];
+		final long max = (long) Math.ceil(
+				indexedData.getMaxValuesPerDimension()[0]);
+		final List<ByteArrayId> insertionIds = new ArrayList<>(
+				(int) (max - min) + 1);
+		for (long i = min; i <= max; i++) {
+			insertionIds.add(
+					new ByteArrayId(
+							lexicoder.toByteArray(
+									cast(
+											i))));
+		}
+		return insertionIds;
+	}
+
+	@Override
+	public NumericDimensionDefinition[] getOrderedDimensionDefinitions() {
+		return definitions;
+	}
+
+	@Override
+	public MultiDimensionalNumericData getRangeForId(
+			final ByteArrayId insertionId ) {
+		final long value = Long.class.cast(
+				lexicoder.fromByteArray(
+						insertionId.getBytes()));
+		final NumericData[] dataPerDimension = new NumericData[] {
+			new NumericValue(
+					value)
+		};
+		return new BasicNumericDataset(
+				dataPerDimension);
+	}
+
+	@Override
+	public long[] getCoordinatesPerDimension(
+			final ByteArrayId insertionId ) {
+		return new long[] {
+			Long.class.cast(
+					lexicoder.fromByteArray(
+							insertionId.getBytes()))
+		};
+	}
+
+	@Override
+	public double[] getHighestPrecisionIdRangePerDimension() {
+		return new double[] {
+			1d
+		};
+	}
+
+	@Override
+	public String getId() {
+		return StringUtils.intToString(
+				hashCode());
+	}
+
+}

--- a/core/index/src/main/java/mil/nga/giat/geowave/core/index/simple/SimpleShortIndexStrategy.java
+++ b/core/index/src/main/java/mil/nga/giat/geowave/core/index/simple/SimpleShortIndexStrategy.java
@@ -1,0 +1,36 @@
+package mil.nga.giat.geowave.core.index.simple;
+
+import mil.nga.giat.geowave.core.index.lexicoder.Lexicoders;
+
+/**
+ * A simple 1-dimensional NumericIndexStrategy that represents an index of
+ * signed short values. The strategy doesn't use any binning. The ids are simply
+ * the byte arrays of the value. This index strategy will not perform well for
+ * inserting ranges because there will be too much replication of data.
+ *
+ */
+public class SimpleShortIndexStrategy extends
+		SimpleNumericIndexStrategy<Short>
+{
+
+	public SimpleShortIndexStrategy() {
+		super(
+				Lexicoders.SHORT);
+	}
+
+	@Override
+	public byte[] toBinary() {
+		return new byte[] {};
+	}
+
+	@Override
+	public void fromBinary(
+			final byte[] bytes ) {}
+
+	@Override
+	protected Short cast(
+			final double value ) {
+		return (short) value;
+	}
+
+}

--- a/core/index/src/test/java/mil/nga/giat/geowave/core/index/lexicoder/IntegerLexicoderTest.java
+++ b/core/index/src/test/java/mil/nga/giat/geowave/core/index/lexicoder/IntegerLexicoderTest.java
@@ -1,0 +1,50 @@
+package mil.nga.giat.geowave.core.index.lexicoder;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.google.common.primitives.UnsignedBytes;
+
+public class IntegerLexicoderTest
+{
+	private final IntegerLexicoder integerLexicoder = Lexicoders.INT;
+
+	@Test
+	public void testRanges() {
+		Assert.assertTrue(integerLexicoder.getMinimumValue().equals(
+				Integer.MIN_VALUE));
+		Assert.assertTrue(integerLexicoder.getMaximumValue().equals(
+				Integer.MAX_VALUE));
+	}
+
+	@Test
+	public void testSortOrder() {
+		final List<Integer> values = Arrays.asList(
+				-10,
+				Integer.MIN_VALUE,
+				2678,
+				Integer.MAX_VALUE,
+				0);
+		final List<byte[]> byteArrays = new ArrayList<>(
+				values.size());
+		for (final int value : values) {
+			byteArrays.add(integerLexicoder.toByteArray(value));
+		}
+		Collections.sort(
+				byteArrays,
+				UnsignedBytes.lexicographicalComparator());
+		Collections.sort(values);
+		final List<Integer> convertedBytes = new ArrayList<>(
+				byteArrays.size());
+		for (final byte[] bytes : byteArrays) {
+			convertedBytes.add(integerLexicoder.fromByteArray(bytes));
+		}
+		Assert.assertTrue(values.equals(convertedBytes));
+	}
+
+}

--- a/core/index/src/test/java/mil/nga/giat/geowave/core/index/lexicoder/IntegerLexicoderTest.java
+++ b/core/index/src/test/java/mil/nga/giat/geowave/core/index/lexicoder/IntegerLexicoderTest.java
@@ -16,10 +16,12 @@ public class IntegerLexicoderTest
 
 	@Test
 	public void testRanges() {
-		Assert.assertTrue(integerLexicoder.getMinimumValue().equals(
-				Integer.MIN_VALUE));
-		Assert.assertTrue(integerLexicoder.getMaximumValue().equals(
-				Integer.MAX_VALUE));
+		Assert.assertTrue(
+				integerLexicoder.getMinimumValue().equals(
+						Integer.MIN_VALUE));
+		Assert.assertTrue(
+				integerLexicoder.getMaximumValue().equals(
+						Integer.MAX_VALUE));
 	}
 
 	@Test
@@ -33,18 +35,25 @@ public class IntegerLexicoderTest
 		final List<byte[]> byteArrays = new ArrayList<>(
 				values.size());
 		for (final int value : values) {
-			byteArrays.add(integerLexicoder.toByteArray(value));
+			byteArrays.add(
+					integerLexicoder.toByteArray(
+							value));
 		}
 		Collections.sort(
 				byteArrays,
 				UnsignedBytes.lexicographicalComparator());
-		Collections.sort(values);
+		Collections.sort(
+				values);
 		final List<Integer> convertedBytes = new ArrayList<>(
 				byteArrays.size());
 		for (final byte[] bytes : byteArrays) {
-			convertedBytes.add(integerLexicoder.fromByteArray(bytes));
+			convertedBytes.add(
+					integerLexicoder.fromByteArray(
+							bytes));
 		}
-		Assert.assertTrue(values.equals(convertedBytes));
+		Assert.assertTrue(
+				values.equals(
+						convertedBytes));
 	}
 
 }

--- a/core/index/src/test/java/mil/nga/giat/geowave/core/index/lexicoder/LongLexicoderTest.java
+++ b/core/index/src/test/java/mil/nga/giat/geowave/core/index/lexicoder/LongLexicoderTest.java
@@ -1,0 +1,49 @@
+package mil.nga.giat.geowave.core.index.lexicoder;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.google.common.primitives.UnsignedBytes;
+
+public class LongLexicoderTest
+{
+	private final LongLexicoder longLexicoder = Lexicoders.LONG;
+
+	@Test
+	public void testRanges() {
+		Assert.assertTrue(longLexicoder.getMinimumValue().equals(
+				Long.MIN_VALUE));
+		Assert.assertTrue(longLexicoder.getMaximumValue().equals(
+				Long.MAX_VALUE));
+	}
+
+	@Test
+	public void testSortOrder() {
+		final List<Long> values = Arrays.asList(
+				-10l,
+				Long.MIN_VALUE,
+				2678l,
+				Long.MAX_VALUE,
+				0l);
+		final List<byte[]> byteArrays = new ArrayList<>(
+				values.size());
+		for (final long value : values) {
+			byteArrays.add(longLexicoder.toByteArray(value));
+		}
+		Collections.sort(
+				byteArrays,
+				UnsignedBytes.lexicographicalComparator());
+		Collections.sort(values);
+		final List<Long> convertedBytes = new ArrayList<>(
+				byteArrays.size());
+		for (final byte[] bytes : byteArrays) {
+			convertedBytes.add(longLexicoder.fromByteArray(bytes));
+		}
+		Assert.assertTrue(values.equals(convertedBytes));
+	}
+}

--- a/core/index/src/test/java/mil/nga/giat/geowave/core/index/lexicoder/LongLexicoderTest.java
+++ b/core/index/src/test/java/mil/nga/giat/geowave/core/index/lexicoder/LongLexicoderTest.java
@@ -16,10 +16,12 @@ public class LongLexicoderTest
 
 	@Test
 	public void testRanges() {
-		Assert.assertTrue(longLexicoder.getMinimumValue().equals(
-				Long.MIN_VALUE));
-		Assert.assertTrue(longLexicoder.getMaximumValue().equals(
-				Long.MAX_VALUE));
+		Assert.assertTrue(
+				longLexicoder.getMinimumValue().equals(
+						Long.MIN_VALUE));
+		Assert.assertTrue(
+				longLexicoder.getMaximumValue().equals(
+						Long.MAX_VALUE));
 	}
 
 	@Test
@@ -33,17 +35,24 @@ public class LongLexicoderTest
 		final List<byte[]> byteArrays = new ArrayList<>(
 				values.size());
 		for (final long value : values) {
-			byteArrays.add(longLexicoder.toByteArray(value));
+			byteArrays.add(
+					longLexicoder.toByteArray(
+							value));
 		}
 		Collections.sort(
 				byteArrays,
 				UnsignedBytes.lexicographicalComparator());
-		Collections.sort(values);
+		Collections.sort(
+				values);
 		final List<Long> convertedBytes = new ArrayList<>(
 				byteArrays.size());
 		for (final byte[] bytes : byteArrays) {
-			convertedBytes.add(longLexicoder.fromByteArray(bytes));
+			convertedBytes.add(
+					longLexicoder.fromByteArray(
+							bytes));
 		}
-		Assert.assertTrue(values.equals(convertedBytes));
+		Assert.assertTrue(
+				values.equals(
+						convertedBytes));
 	}
 }

--- a/core/index/src/test/java/mil/nga/giat/geowave/core/index/lexicoder/ShortLexicoderTest.java
+++ b/core/index/src/test/java/mil/nga/giat/geowave/core/index/lexicoder/ShortLexicoderTest.java
@@ -1,0 +1,49 @@
+package mil.nga.giat.geowave.core.index.lexicoder;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.google.common.primitives.UnsignedBytes;
+
+public class ShortLexicoderTest
+{
+	private final ShortLexicoder shortLexicoder = Lexicoders.SHORT;
+
+	@Test
+	public void testRanges() {
+		Assert.assertTrue(shortLexicoder.getMinimumValue().equals(
+				Short.MIN_VALUE));
+		Assert.assertTrue(shortLexicoder.getMaximumValue().equals(
+				Short.MAX_VALUE));
+	}
+
+	@Test
+	public void testSortOrder() {
+		final List<Short> values = Arrays.asList(
+				(short) -10,
+				Short.MIN_VALUE,
+				(short) 2678,
+				Short.MAX_VALUE,
+				(short) 0);
+		final List<byte[]> byteArrays = new ArrayList<>(
+				values.size());
+		for (final short value : values) {
+			byteArrays.add(shortLexicoder.toByteArray(value));
+		}
+		Collections.sort(
+				byteArrays,
+				UnsignedBytes.lexicographicalComparator());
+		Collections.sort(values);
+		final List<Short> convertedBytes = new ArrayList<>(
+				byteArrays.size());
+		for (final byte[] bytes : byteArrays) {
+			convertedBytes.add(shortLexicoder.fromByteArray(bytes));
+		}
+		Assert.assertTrue(values.equals(convertedBytes));
+	}
+}

--- a/core/index/src/test/java/mil/nga/giat/geowave/core/index/lexicoder/ShortLexicoderTest.java
+++ b/core/index/src/test/java/mil/nga/giat/geowave/core/index/lexicoder/ShortLexicoderTest.java
@@ -16,10 +16,12 @@ public class ShortLexicoderTest
 
 	@Test
 	public void testRanges() {
-		Assert.assertTrue(shortLexicoder.getMinimumValue().equals(
-				Short.MIN_VALUE));
-		Assert.assertTrue(shortLexicoder.getMaximumValue().equals(
-				Short.MAX_VALUE));
+		Assert.assertTrue(
+				shortLexicoder.getMinimumValue().equals(
+						Short.MIN_VALUE));
+		Assert.assertTrue(
+				shortLexicoder.getMaximumValue().equals(
+						Short.MAX_VALUE));
 	}
 
 	@Test
@@ -33,17 +35,24 @@ public class ShortLexicoderTest
 		final List<byte[]> byteArrays = new ArrayList<>(
 				values.size());
 		for (final short value : values) {
-			byteArrays.add(shortLexicoder.toByteArray(value));
+			byteArrays.add(
+					shortLexicoder.toByteArray(
+							value));
 		}
 		Collections.sort(
 				byteArrays,
 				UnsignedBytes.lexicographicalComparator());
-		Collections.sort(values);
+		Collections.sort(
+				values);
 		final List<Short> convertedBytes = new ArrayList<>(
 				byteArrays.size());
 		for (final byte[] bytes : byteArrays) {
-			convertedBytes.add(shortLexicoder.fromByteArray(bytes));
+			convertedBytes.add(
+					shortLexicoder.fromByteArray(
+							bytes));
 		}
-		Assert.assertTrue(values.equals(convertedBytes));
+		Assert.assertTrue(
+				values.equals(
+						convertedBytes));
 	}
 }

--- a/core/index/src/test/java/mil/nga/giat/geowave/core/index/simple/SimpleNumericIndexStrategyTest.java
+++ b/core/index/src/test/java/mil/nga/giat/geowave/core/index/simple/SimpleNumericIndexStrategyTest.java
@@ -1,0 +1,241 @@
+package mil.nga.giat.geowave.core.index.simple;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.google.common.primitives.UnsignedBytes;
+
+import mil.nga.giat.geowave.core.index.ByteArrayId;
+import mil.nga.giat.geowave.core.index.ByteArrayRange;
+import mil.nga.giat.geowave.core.index.sfc.data.BasicNumericDataset;
+import mil.nga.giat.geowave.core.index.sfc.data.MultiDimensionalNumericData;
+import mil.nga.giat.geowave.core.index.sfc.data.NumericData;
+import mil.nga.giat.geowave.core.index.sfc.data.NumericRange;
+import mil.nga.giat.geowave.core.index.sfc.data.NumericValue;
+
+@RunWith(Parameterized.class)
+public class SimpleNumericIndexStrategyTest
+{
+
+	private final SimpleNumericIndexStrategy<? extends Number> strategy;
+
+	public SimpleNumericIndexStrategyTest(
+			final SimpleNumericIndexStrategy<?> strategy ) {
+		this.strategy = strategy;
+	}
+
+	@Parameters
+	public static Collection<Object[]> instancesToTest() {
+		return Arrays.asList(
+				new Object[] {
+					new SimpleShortIndexStrategy()
+		},
+				new Object[] {
+					new SimpleIntegerIndexStrategy()
+		},
+				new Object[] {
+					new SimpleLongIndexStrategy()
+		});
+	}
+
+	private static long castToLong(
+			final Number n ) {
+		if (n instanceof Short) {
+			return ((short) n);
+		}
+		else if (n instanceof Integer) {
+			return ((int) n);
+		}
+		else if (n instanceof Long) {
+			return (long) n;
+		}
+		else {
+			throw new UnsupportedOperationException(
+					"only supports casting Short, Integer, and Long");
+		}
+	}
+
+	private static MultiDimensionalNumericData getIndexedRange(
+			final long value ) {
+		return getIndexedRange(
+				value,
+				value);
+	}
+
+	private static MultiDimensionalNumericData getIndexedRange(
+			final long min,
+			final long max ) {
+		NumericData[] dataPerDimension;
+		if (min == max) {
+			dataPerDimension = new NumericData[] {
+				new NumericValue(
+						min)
+			};
+		}
+		else {
+			dataPerDimension = new NumericData[] {
+				new NumericRange(
+						min,
+						max)
+			};
+		}
+		return new BasicNumericDataset(
+				dataPerDimension);
+	}
+
+	private byte[] getByteArray(
+			final long value ) {
+		final MultiDimensionalNumericData indexedRange = getIndexedRange(
+				value);
+		final List<ByteArrayId> insertionIds = strategy.getInsertionIds(
+				indexedRange);
+		final ByteArrayId insertionId = insertionIds.get(
+				0);
+		return insertionId.getBytes();
+	}
+
+	@Test
+	public void testGetQueryRangesPoint() {
+		final MultiDimensionalNumericData indexedRange = getIndexedRange(
+				10l);
+		final List<ByteArrayRange> ranges = strategy.getQueryRanges(
+				indexedRange);
+		Assert.assertEquals(
+				ranges.size(),
+				1);
+		final ByteArrayRange range = ranges.get(
+				0);
+		final ByteArrayId start = range.getStart();
+		final ByteArrayId end = range.getEnd();
+		Assert.assertTrue(
+				Arrays.equals(
+						start.getBytes(),
+						end.getBytes()));
+		Assert.assertEquals(
+				10L,
+				castToLong(
+						strategy.getLexicoder().fromByteArray(
+								start.getBytes())));
+	}
+
+	@Test
+	public void testGetQueryRangesRange() {
+		final long startValue = 10;
+		final long endValue = 15;
+		final MultiDimensionalNumericData indexedRange = getIndexedRange(
+				startValue,
+				endValue);
+		final List<ByteArrayRange> ranges = strategy.getQueryRanges(
+				indexedRange);
+		Assert.assertEquals(
+				ranges.size(),
+				1);
+		final ByteArrayRange range = ranges.get(
+				0);
+		final ByteArrayId start = range.getStart();
+		final ByteArrayId end = range.getEnd();
+		Assert.assertEquals(
+				castToLong(
+						strategy.getLexicoder().fromByteArray(
+								start.getBytes())),
+				startValue);
+		Assert.assertEquals(
+				castToLong(
+						strategy.getLexicoder().fromByteArray(
+								end.getBytes())),
+				endValue);
+	}
+
+	/**
+	 * Check that lexicographical sorting of the byte arrays yields the same
+	 * sort order as sorting the values
+	 */
+	@Test
+	public void testRangeSortOrder() {
+		final List<Long> values = Arrays.asList(
+				10l,
+				0l,
+				15l,
+				-275l,
+				982l,
+				430l,
+				-1l,
+				1l,
+				82l);
+		final List<byte[]> byteArrays = new ArrayList<>(
+				values.size());
+		for (final long value : values) {
+			final byte[] bytes = getByteArray(
+					value);
+			byteArrays.add(
+					bytes);
+		}
+		Collections.sort(
+				values);
+		Collections.sort(
+				byteArrays,
+				UnsignedBytes.lexicographicalComparator());
+		final List<Long> convertedValues = new ArrayList<>(
+				values.size());
+		for (final byte[] bytes : byteArrays) {
+			final long value = castToLong(
+					strategy.getLexicoder().fromByteArray(
+							bytes));
+			convertedValues.add(
+					value);
+		}
+		Assert.assertTrue(
+				values.equals(
+						convertedValues));
+	}
+
+	@Test
+	public void testGetInsertionIdsPoint() {
+		final long pointValue = 5926;
+		final MultiDimensionalNumericData indexedData = getIndexedRange(
+				pointValue);
+		final List<ByteArrayId> insertionIds = strategy.getInsertionIds(
+				indexedData);
+		Assert.assertEquals(
+				insertionIds.size(),
+				1);
+		final ByteArrayId insertionId = insertionIds.get(
+				0);
+		Assert.assertEquals(
+				castToLong(
+						strategy.getLexicoder().fromByteArray(
+								insertionId.getBytes())),
+				pointValue);
+	}
+
+	@Test
+	public void testGetInsertionIdsRange() {
+		final long startValue = 9876;
+		final long endValue = startValue + 15;
+		final MultiDimensionalNumericData indexedData = getIndexedRange(
+				startValue,
+				endValue);
+		final List<ByteArrayId> insertionIds = strategy.getInsertionIds(
+				indexedData);
+		Assert.assertEquals(
+				insertionIds.size(),
+				(int) ((endValue - startValue) + 1));
+		int i = 0;
+		for (final ByteArrayId insertionId : insertionIds) {
+			Assert.assertEquals(
+					castToLong(
+							strategy.getLexicoder().fromByteArray(
+									insertionId.getBytes())),
+					startValue + i++);
+		}
+	}
+}


### PR DESCRIPTION
This is an implementation of a simple 1-dimensional NumericIndexStrategy for indexing integer values. Can index keys of different sizes by using the appropriate lexicoder (short, int, or long are currently implemented). This index strategy will not work well for range insertions. See commit comments for more detail.