### PR TITLE
Allow for more dynamic SimpleFeature Retyping

### DIFF
--- a/extensions/formats/geotools-vector/src/main/java/mil/nga/giat/geowave/format/geotools/vector/AbstractFieldRetypingSource.java
+++ b/extensions/formats/geotools-vector/src/main/java/mil/nga/giat/geowave/format/geotools/vector/AbstractFieldRetypingSource.java
@@ -1,0 +1,58 @@
+package mil.nga.giat.geowave.format.geotools.vector;
+
+import mil.nga.giat.geowave.format.geotools.vector.RetypingVectorDataPlugin.RetypingVectorDataSource;
+
+import org.geoserver.feature.RetypingFeatureCollection;
+import org.geotools.feature.simple.SimpleFeatureBuilder;
+import org.opengis.feature.simple.SimpleFeature;
+import org.opengis.feature.simple.SimpleFeatureType;
+import org.opengis.feature.type.AttributeDescriptor;
+import org.opengis.feature.type.Name;
+import org.opengis.filter.identity.FeatureId;
+
+abstract public class AbstractFieldRetypingSource implements
+		RetypingVectorDataSource
+{
+
+	abstract public String getFeatureId(
+			SimpleFeature original );
+
+	abstract public Object retypeAttributeValue(
+			Object value,
+			Name attributeName );
+
+	@Override
+	public SimpleFeature getRetypedSimpleFeature(
+			SimpleFeatureBuilder builder,
+			SimpleFeature original ) {
+
+		final SimpleFeatureType target = builder.getFeatureType();
+		for (int i = 0; i < target.getAttributeCount(); i++) {
+			final AttributeDescriptor attributeType = target.getDescriptor(i);
+			Object value = null;
+
+			if (original.getFeatureType().getDescriptor(
+					attributeType.getName()) != null) {
+				final Name name = attributeType.getName();
+				value = retypeAttributeValue(
+						original.getAttribute(name),
+						name);
+			}
+
+			builder.add(value);
+		}
+		String featureId = getFeatureId(original);
+		if (featureId == null) {
+			// a null ID will default to use the original
+			final FeatureId id = RetypingFeatureCollection.reTypeId(
+					original.getIdentifier(),
+					original.getFeatureType(),
+					target);
+			featureId = id.getID();
+		}
+		final SimpleFeature retyped = builder.buildFeature(featureId);
+		retyped.getUserData().putAll(
+				original.getUserData());
+		return retyped;
+	}
+}

--- a/extensions/formats/geotools-vector/src/main/java/mil/nga/giat/geowave/format/geotools/vector/RetypingVectorDataPlugin.java
+++ b/extensions/formats/geotools-vector/src/main/java/mil/nga/giat/geowave/format/geotools/vector/RetypingVectorDataPlugin.java
@@ -1,8 +1,8 @@
 package mil.nga.giat.geowave.format.geotools.vector;
 
+import org.geotools.feature.simple.SimpleFeatureBuilder;
 import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;
-import org.opengis.feature.type.Name;
 
 public interface RetypingVectorDataPlugin
 {
@@ -13,11 +13,8 @@ public interface RetypingVectorDataPlugin
 	{
 		public SimpleFeatureType getRetypedSimpleFeatureType();
 
-		public Object retypeAttributeValue(
-				Object value,
-				Name attributeName );
-
-		public String getFeatureId(
+		public SimpleFeature getRetypedSimpleFeature(
+				SimpleFeatureBuilder retypeBuilder,
 				SimpleFeature original );
 	}
 }

--- a/extensions/formats/geotools-vector/src/main/java/mil/nga/giat/geowave/format/geotools/vector/retyping/date/DateFieldRetypingSource.java
+++ b/extensions/formats/geotools-vector/src/main/java/mil/nga/giat/geowave/format/geotools/vector/retyping/date/DateFieldRetypingSource.java
@@ -7,7 +7,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import mil.nga.giat.geowave.format.geotools.vector.RetypingVectorDataPlugin.RetypingVectorDataSource;
+import mil.nga.giat.geowave.format.geotools.vector.AbstractFieldRetypingSource;
 
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
@@ -17,8 +17,8 @@ import org.opengis.feature.simple.SimpleFeatureType;
 import org.opengis.feature.type.AttributeDescriptor;
 import org.opengis.feature.type.Name;
 
-public class DateFieldRetypingSource implements
-		RetypingVectorDataSource
+public class DateFieldRetypingSource extends
+		AbstractFieldRetypingSource
 {
 	private final static Logger LOGGER = Logger.getLogger(DateFieldRetypingSource.class);
 


### PR DESCRIPTION
See #492 

Grants RetypingVectorDataSource more control over the feature being retyped.  Existing logic was moved to AbstractFieldRetypingSource and existing implementations can simply inherit from that abstract class instead.