### PR TITLE
Added .DS_Store to .gitignore file for Mac OSX developers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dependency-reduced-pom.xml
 *.imls
 *.iml
 .idea/
+.DS_Store


### PR DESCRIPTION
Trivial .gitignore file update to disregard .DS_Store files in every direction on Mac OSX.