### PR TITLE
Exclude service jars from getting packaged with plugins

### DIFF
--- a/deploy/packaging/rpm/admin-scripts/jenkins-build-geowave.sh
+++ b/deploy/packaging/rpm/admin-scripts/jenkins-build-geowave.sh
@@ -9,7 +9,7 @@ cd $WORKSPACE/deploy
 # Create an archive of all the ingest format plugins
 mkdir -p target/plugins >/dev/null 2>&1
 pushd target/plugins
-find $WORKSPACE/extensions/formats -name "*.jar" -exec cp {} . \;
+find $WORKSPACE/extensions/formats -name "*.jar" -not -path "*/service/target/*" -exec cp {} . \;
 tar cvzf ../plugins.tar.gz *.jar
 popd
 


### PR DESCRIPTION
Only include plugin jars and not unrelated service jars into plugins.tar.gz archive that gets used by the RPM process.