### PR TITLE
Build and RPM GeoWave components using Docker containers

### DIFF
--- a/deploy/packaging/docker/.gitignore
+++ b/deploy/packaging/docker/.gitignore
@@ -1,0 +1,1 @@
+build-args-matrix.sh

--- a/deploy/packaging/docker/README.md
+++ b/deploy/packaging/docker/README.md
@@ -1,0 +1,60 @@
+## Step #1: Configure a Docker build host
+
+A host to run the GeoWave build containers needs just Docker, Git and the Unzip commands available. Tested Docker
+configurations are shown below but any OS capable of running Docker containers should work.
+
+### Redhat7/CentOS7 Docker Build Host
+
+```
+sudo yum -y install docker git unzip
+sudo systemctl start docker
+sudo systemctl enable docker
+```
+
+### Ubuntu 14.04 Build Host
+```
+sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9
+sudo sh -c "echo deb https://get.docker.com/ubuntu docker main > /etc/apt/sources.list.d/docker.list"
+sudo apt-get update
+sudo apt-get -y install lxc-docker git unzip
+```
+
+### Docker Test
+
+Before continuing test that Docker is available with the `sudo docker info` command
+
+## Step #2: GeoWave Source Code
+
+From the docker build host we're going to clone the GeoWave repo and then by using volume mounts 
+we'll allow the various containers to build and/or package the code without the need to then copy 
+the finished artifacts back out of the container.
+
+```
+git clone --depth 1 https://github.com/ngageoint/geowave.git
+```
+
+## Step #3: Create Docker Images for Building
+
+We'll eventually publish these images, until then you'll have to build them locally
+
+```
+pushd geowave/deploy/packaging/docker
+sudo docker build -t ngageoint/geowave-centos6-java8-build -f geowave-centos6-java8-build.dockerfile .   
+sudo docker build -t ngageoint/geowave-centos6-rpm-build -f geowave-centos6-rpm-build.dockerfile .
+popd
+```
+
+## Step #4: Build GeoWave Artifacts and RPMs
+
+The docker-build-rpms script will coordinate a series of container builds resulting in finished jar and rpm artifacts
+built for each of the desired build configurations (ex: cdh5, hortonworks or apache).
+
+```
+export WORKSPACE="$(pwd)/geowave"
+export SKIP_TESTS="-Dfindbugs.skip=true -DskipFormat=true -DskipITs=true -DskipTests=true" # (Optional)
+sudo chown -R $(whoami) geowave/deploy/packaging
+geowave/deploy/packaging/docker/docker-build-rpms.sh
+```
+
+After the docker-build-rpms.sh command has finished the rpms can be found in the 
+`geowave/deploy/packaging/rpm/centos/6/RPMS/noarch/` directory adjusting the version of the OS as needed.

--- a/deploy/packaging/docker/build-args-matrix.sh.example
+++ b/deploy/packaging/docker/build-args-matrix.sh.example
@@ -1,0 +1,8 @@
+#!/bin/bash
+#
+# Custom build args matrix config file
+# Remove the .example from the name of the file and add/remove/update the build args as desired
+
+BUILD_ARGS_MATRIX=(
+  "-Daccumulo.version=1.6.0-cdh5.1.4 -Dhadoop.version=2.6.0-cdh5.4.0 -Dgeotools.version=13.0 -Dgeoserver.version=2.7.0 -Dvendor.version=cdh5 -P cloudera"
+)

--- a/deploy/packaging/docker/build-rpm.sh
+++ b/deploy/packaging/docker/build-rpm.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+#
+# This script will build a single set of rpms for a given configuration
+#
+
+# Set a default version
+VENDOR_VERSION=cdh
+
+if [ -z $GEOSERVER_DOWNLOAD_BASE ]; then
+	GEOSERVER_DOWNLOAD_BASE=https://s3.amazonaws.com/geowave/third-party-downloads/geoserver
+fi
+
+if [ -z $GEOSERVER_VERSION ]; then
+	GEOSERVER_VERSION=geoserver-2.7.3-bin.zip
+fi
+
+GEOSERVER_ARTIFACT=/usr/src/geowave/deploy/packaging/rpm/centos/6/SOURCES/geoserver.zip
+if [ ! -f "$GEOSERVER_ARTIFACT" ]; then
+	curl $GEOSERVER_DOWNLOAD_BASE/$GEOSERVER_VERSION > $GEOSERVER_ARTIFACT
+fi
+
+if [ ! -z "$BUILD_ARGS" ]; then
+	VENDOR_VERSION=$(echo "$BUILD_ARGS" | grep -oi "vendor.version=\w*" | sed "s/vendor.version=//g")
+fi
+
+echo "---------------------------------------------------------------"
+echo "             Building RPM with the following settings"
+echo "---------------------------------------------------------------"
+echo "GEOSERVER_VERSION=${GEOSERVER_VERSION}"
+echo "BUILD_ARGS=${BUILD_ARGS}"
+echo "VENDOR_VERSION=${VENDOR_VERSION}"
+echo "---------------------------------------------------------------"
+
+# Ensure mounted volume permissions are OK for access
+chown -R root:root /usr/src/geowave/deploy
+
+# Staging Artifacts for Build
+cd /usr/src/geowave/deploy/packaging/rpm/centos/6/SOURCES
+rm -f *.gz *.jar
+cp /usr/src/geowave/target/site.tar.gz .
+cp /usr/src/geowave/docs/target/manpages.tar.gz .
+cp /usr/src/geowave/deploy/target/*.jar .
+cp /usr/src/geowave/deploy/target/*.tar.gz .
+cd ..
+
+# Build
+./rpm.sh --command build --vendor-version $VENDOR_VERSION

--- a/deploy/packaging/docker/docker-build-rpms.sh
+++ b/deploy/packaging/docker/docker-build-rpms.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+#
+# This script will build and package all of the configurations listed in teh BUILD_ARGS_MATRIX array.
+#
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "$SCRIPT_DIR/../../.."
+WORKSPACE="$(pwd)"
+
+# selinux config if needed
+type getenforce >/dev/null 2>&1 && getenforce >/dev/null 2>&1 && chcon -Rt svirt_sandbox_file_t $WORKSPACE;
+
+# If you'd like to build a different set of artifacts rename build-args-matrix.sh.example
+if [ -f $SCRIPT_DIR/build-args-matrix.sh ]; then
+	source $SCRIPT_DIR/build-args-matrix.sh
+else
+	# Default build arguments
+    BUILD_ARGS_MATRIX=(
+      "-Daccumulo.version=1.6.0-cdh5.1.4 -Dhadoop.version=2.6.0-cdh5.4.0 -Dgeotools.version=13.0 -Dgeoserver.version=2.7.3 -Dvendor.version=cdh5 -P cloudera"
+      "-Daccumulo.version=1.6.2 -Dhadoop.version=2.6.0 -Dgeotools.version=13.2 -Dgeoserver.version=2.7.3 -Dvendor.version=apache -Dvendor.version=apache -P \"\""
+      "-Daccumulo.version=1.6.1.2.2.4.0-2633 -Dhadoop.version=2.6.0.2.2.4.0-2633 -Dgeotools.version=13.2 -Dgeoserver.version=2.7.3 -Dvendor.version=hdp2 -P hortonworks"
+    )
+fi
+
+export MVN_PACKAGE_FAT_JARS_CMD="/usr/src/geowave/deploy/packaging/rpm/admin-scripts/jenkins-build-geowave.sh $SKIP_TESTS"
+
+$WORKSPACE/deploy/packaging/docker/pull-s3-caches.sh
+$WORKSPACE/deploy/packaging/rpm/centos/6/rpm.sh --command clean
+
+for build_args in "${BUILD_ARGS_MATRIX[@]}"
+do
+	export BUILD_ARGS="$build_args"
+	export MVN_BUILD_AND_TEST_CMD="mvn install $SKIP_TESTS $BUILD_ARGS"
+
+	sudo docker run --rm \
+		-e WORKSPACE=/usr/src/geowave \
+		-e BUILD_ARGS="$build_args" \
+		-e MAVEN_OPTS="-Xmx1500m" \
+		-v $HOME:/root -v $HOME/geowave:/usr/src/geowave \
+		ngageoint/geowave-centos6-java8-build \
+		/bin/bash -c \
+		"cd \$WORKSPACE && $MVN_BUILD_AND_TEST_CMD && $MVN_PACKAGE_FAT_JARS_CMD"
+
+	sudo docker run --rm \
+    	-e WORKSPACE=/usr/src/geowave \
+    	-e BUILD_ARGS="$build_args" \
+    	-v $HOME/geowave:/usr/src/geowave \
+    	ngageoint/geowave-centos6-rpm-build \
+    	/bin/bash -c \
+    	"cd \$WORKSPACE && deploy/packaging/docker/build-rpm.sh"
+done
+sudo chown -R $(whoami) $WORKSPACE/deploy/packaging

--- a/deploy/packaging/docker/geowave-centos6-java7-build.dockerfile
+++ b/deploy/packaging/docker/geowave-centos6-java7-build.dockerfile
@@ -1,0 +1,15 @@
+FROM centos:centos6
+
+RUN yum -y install asciidoc boost boost-devel gcc-c++ git glibc.i686 tar unzip which wget xmlto && \
+	yum clean all
+
+RUN cd /tmp && wget --no-check-certificate --no-cookies \
+	--header "Cookie: oraclelicense=accept-securebackup-cookie"  \
+	http://download.oracle.com/otn-pub/java/jdk/7u79-b15/jdk-7u79-linux-x64.rpm -q && \
+	rpm -Uvh /tmp/*.rpm && rm -fr /tmp/*.rpm && \
+	wget http://archive.apache.org/dist/maven/binaries/apache-maven-3.2.2-bin.zip && \
+	unzip apache-maven-3.2.2-bin.zip && \
+	mv apache-maven-3.2.2/ /opt/maven && \
+	ln -s /opt/maven/bin/mvn /usr/bin/mvn && \
+	rm -rf apache-maven-3.2.2-bin.zip && \
+	echo "export JAVA_HOME=/usr/java/latest" > /etc/profile.d/java_home.sh && cd ~

--- a/deploy/packaging/docker/geowave-centos6-java8-build.dockerfile
+++ b/deploy/packaging/docker/geowave-centos6-java8-build.dockerfile
@@ -1,0 +1,15 @@
+FROM centos:centos6
+
+RUN yum -y install asciidoc boost boost-devel gcc-c++ git glibc.i686 tar unzip which wget xmlto && \
+	yum clean all
+
+RUN cd /tmp && wget --no-check-certificate --no-cookies \
+	--header "Cookie: oraclelicense=accept-securebackup-cookie"  \
+	http://download.oracle.com/otn-pub/java/jdk/8u60-b27/jdk-8u60-linux-x64.rpm -q && \
+	rpm -Uvh /tmp/*.rpm && rm -fr /tmp/*.rpm && \
+	wget http://archive.apache.org/dist/maven/binaries/apache-maven-3.2.2-bin.zip && \
+	unzip apache-maven-3.2.2-bin.zip && \
+	mv apache-maven-3.2.2/ /opt/maven && \
+	ln -s /opt/maven/bin/mvn /usr/bin/mvn && \
+	rm -rf apache-maven-3.2.2-bin.zip && \
+	echo "export JAVA_HOME=/usr/java/latest" > /etc/profile.d/java_home.sh && cd ~

--- a/deploy/packaging/docker/geowave-centos6-rpm-build.dockerfile
+++ b/deploy/packaging/docker/geowave-centos6-rpm-build.dockerfile
@@ -1,0 +1,4 @@
+FROM centos:centos6
+
+RUN yum -y install asciidoc rpm-build rpm2cpio tar unzip xmlto zip && \
+	yum clean all

--- a/deploy/packaging/docker/pull-s3-caches.sh
+++ b/deploy/packaging/docker/pull-s3-caches.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# If we've not specifically disabled and there is no current Maven repo
+# pull a cache from S3 so the first run won't take forever
+if [ -z $NO_MAVEN_INIT ] && [ ! -d ~/.m2 ]; then
+	echo "Downloading Maven Cache ..."
+	MVN_CACHE_BASE=https://s3.amazonaws.com/geowave-maven/cache-bundle
+	CACHE_FILE=mvn-repo-cache-20151021.tar
+	pushd ~
+	curl -O $MVN_CACHE_BASE/$CACHE_FILE
+	tar xf $CACHE_FILE
+	rm -f $CACHE_FILE
+	popd
+	type getenforce >/dev/null 2>&1 &&  getenforce >/dev/null 2>&1 && chcon -Rt svirt_sandbox_file_t ~/.m2;
+	echo "Finished Downloading Maven Cache ..."
+fi

--- a/deploy/packaging/rpm/admin-scripts/jenkins-build-geowave.sh
+++ b/deploy/packaging/rpm/admin-scripts/jenkins-build-geowave.sh
@@ -2,7 +2,12 @@
 #
 # GeoWave Jenkins Build Script
 #
-# In the Execute Shell block before calling this script set the versions
+
+echo "---------------------------------------------------------------"
+echo "         Building GeoWave with the following settings"
+echo "---------------------------------------------------------------"
+echo "BUILD_ARGS=${BUILD_ARGS} ${@}"
+echo "---------------------------------------------------------------"
 
 cd $WORKSPACE/deploy
 
@@ -44,41 +49,51 @@ $WORKSPACE/.utility/maven-jace-hack.sh
 
 # Build the debug bindings
 cd $WORKSPACE/deploy
-mvn package -P generate-jace-proxies,linux-amd64-gcc-debug $BUILD_ARGS "$@"
-mv $WORKSPACE/deploy/target/*-jace.jar $WORKSPACE/deploy/target/jace/geowave-jace.jar
-tar -czf $WORKSPACE/deploy/target/jace-linux-amd64-debug.tar.gz \
-    -C $WORKSPACE/deploy/target/jace geowave-ingest.jar \
-    -C $WORKSPACE/deploy/target/jace geowave-jace.jar \
-    -C $WORKSPACE/deploy/target/dependency/jace libjace.so \
-    -C $WORKSPACE/deploy/target/dependency/jace include
+if [ ! -f $WORKSPACE/deploy/target/jace-linux-amd64-debug.tar.gz ]; then
+    mvn package -P generate-jace-proxies,linux-amd64-gcc-debug $BUILD_ARGS "$@"
+    mv $WORKSPACE/deploy/target/*-jace.jar $WORKSPACE/deploy/target/jace/geowave-jace.jar
+    tar -czf $WORKSPACE/deploy/target/jace-linux-amd64-debug.tar.gz \
+        -C $WORKSPACE/deploy/target/jace geowave-ingest.jar \
+        -C $WORKSPACE/deploy/target/jace geowave-jace.jar \
+        -C $WORKSPACE/deploy/target/dependency/jace libjace.so \
+        -C $WORKSPACE/deploy/target/dependency/jace include
+fi
 
 # Build the release bindings
-mvn package -P generate-jace-proxies,linux-amd64-gcc-release $BUILD_ARGS "$@"
-tar -czf $WORKSPACE/deploy/target/jace-linux-amd64-release.tar.gz \
-    -C $WORKSPACE/deploy/target/jace geowave-ingest.jar \
-    -C $WORKSPACE/deploy/target/jace geowave-jace.jar \
-    -C $WORKSPACE/deploy/target/dependency/jace libjace.so \
-    -C $WORKSPACE/deploy/target/dependency/jace include
+if [ ! -f $WORKSPACE/deploy/target/jace-linux-amd64-release.tar.gz ] || [ ! -f $WORKSPACE/deploy/target/jace-source.tar.gz ]; then
+    mvn package -P generate-jace-proxies,linux-amd64-gcc-release $BUILD_ARGS "$@"
+    tar -czf $WORKSPACE/deploy/target/jace-linux-amd64-release.tar.gz \
+        -C $WORKSPACE/deploy/target/jace geowave-ingest.jar \
+        -C $WORKSPACE/deploy/target/jace geowave-jace.jar \
+        -C $WORKSPACE/deploy/target/dependency/jace libjace.so \
+        -C $WORKSPACE/deploy/target/dependency/jace include
 
-tar -czf $WORKSPACE/deploy/target/jace-source.tar.gz \
-    -C $WORKSPACE/deploy/target/jace geowave-ingest.jar \
-    -C $WORKSPACE/deploy/target/jace geowave-jace.jar \
-    -C $WORKSPACE/deploy/target/dependency/jace CMakeLists.txt \
-    -C $WORKSPACE/deploy/target/dependency/jace source \
-    -C $WORKSPACE/deploy/target/dependency/jace include
+    tar -czf $WORKSPACE/deploy/target/jace-source.tar.gz \
+        -C $WORKSPACE/deploy/target/jace geowave-ingest.jar \
+        -C $WORKSPACE/deploy/target/jace geowave-jace.jar \
+        -C $WORKSPACE/deploy/target/dependency/jace CMakeLists.txt \
+        -C $WORKSPACE/deploy/target/dependency/jace source \
+        -C $WORKSPACE/deploy/target/dependency/jace include
+fi
 
 # Build and archive HTML/PDF docs
 cd $WORKSPACE/
-mvn javadoc:aggregate
-mvn -P docs -pl docs install
-tar -czf $WORKSPACE/target/site.tar.gz -C $WORKSPACE/target site
+if [ ! -f $WORKSPACE/target/site.tar.gz ]; then
+    mvn javadoc:aggregate
+    mvn -P docs -pl docs install
+    tar -czf $WORKSPACE/target/site.tar.gz -C $WORKSPACE/target site
+fi
 
 # Build and archive the man pages
-mkdir -p $WORKSPACE/docs/target/{asciidoc,manpages}
-cp -fR $WORKSPACE/docs/content/manpages/* $WORKSPACE/docs/target/asciidoc
-find $WORKSPACE/docs/target/asciidoc/ -name "*.txt" -exec sed -i "s|//:||" {} \;
-find $WORKSPACE/docs/target/asciidoc/ -name "*.txt" -exec a2x -d manpage -f manpage {} -D $WORKSPACE/docs/target/manpages \;
-tar -czf $WORKSPACE/docs/target/manpages.tar.gz -C $WORKSPACE/docs/target/manpages/ .
+if [ ! -f $WORKSPACE/docs/target/manpages.tar.gz ]; then
+    mkdir -p $WORKSPACE/docs/target/{asciidoc,manpages}
+    cp -fR $WORKSPACE/docs/content/manpages/* $WORKSPACE/docs/target/asciidoc
+    find $WORKSPACE/docs/target/asciidoc/ -name "*.txt" -exec sed -i "s|//:||" {} \;
+    find $WORKSPACE/docs/target/asciidoc/ -name "*.txt" -exec a2x -d manpage -f manpage {} -D $WORKSPACE/docs/target/manpages \;
+    tar -czf $WORKSPACE/docs/target/manpages.tar.gz -C $WORKSPACE/docs/target/manpages/ .
+fi
 
 ## Copy over the puppet scripts
-tar -czf $WORKSPACE/deploy/target/puppet-scripts.tar.gz -C $WORKSPACE/deploy/packaging/puppet geowave
+if [ ! -f $WORKSPACE/deploy/target/puppet-scripts.tar.gz ]; then
+    tar -czf $WORKSPACE/deploy/target/puppet-scripts.tar.gz -C $WORKSPACE/deploy/packaging/puppet geowave
+fi

--- a/deploy/packaging/rpm/admin-scripts/rpm-functions.sh
+++ b/deploy/packaging/rpm/admin-scripts/rpm-functions.sh
@@ -11,9 +11,6 @@ ADMIN_SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # When sourcing this script the directory of the calling script is passed
 CALLING_SCRIPT_DIR=$1
 
-# All of these apps need to be installed on a system to run this script
-REQUIRED_APPS=('awk' 'curl' 'sed' 'unzip' 'rpmbuild' 'rpm2cpio')
-
 about() {
 	echo "Usage: $0 --command [clean|update|build]"
 	echo "	clean  - Removes build files and RPMs"
@@ -101,14 +98,6 @@ clean() {
     rm -rf $CALLING_SCRIPT_DIR/TARBALL/*
 }
 
-# Test for installed apps required to run this script
-dependency_tests() {
-	for app in "${REQUIRED_APPS[@]}"
-	do
-		type $app >/dev/null 2>&1 || { echo >&2 "$0 needs the $app command to be installed.  Aborting."; exit 1; }	
-	done
-}
-
 # All configurable strings should be externalized to a props file
 source_props() {
 	. $ADMIN_SCRIPTS_DIR/default-props.sh
@@ -153,8 +142,6 @@ update_artifact() {
  		echo $CMD # If under test environment
  	fi
 }
-
-dependency_tests
 
 if [ ! -d "$CALLING_SCRIPT_DIR" ]; then
 	echo >&2 "Usage: . $0 [calling script directory]"

--- a/deploy/packaging/rpm/centos/6/rpm.sh
+++ b/deploy/packaging/rpm/centos/6/rpm.sh
@@ -3,8 +3,10 @@
 # RPM build script
 #
 
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
 # Source all our reusable functionality, argument is the location of this script.
-. ../../admin-scripts/rpm-functions.sh "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+. "$SCRIPT_DIR/../../admin-scripts/rpm-functions.sh" "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 declare -A ARGS
 while [ $# -gt 0 ]; do

--- a/docs/content/090-building.adoc
+++ b/docs/content/090-building.adoc
@@ -51,3 +51,14 @@ Integration Tests: Windows
 Integration tests are currently not working on Windows out of the box. If you install cygwin and set the environmental variable CYGPATH to the
 location of the cygpath binary provided by cygwin then is should work. Eclipse and Avro generated files
 ====
+
+=== Docker Build Process
+
+We have preliminary support for building both the GeoWave jar artifacts and RPMs from Docker containers. This capability is
+useful for a number of different situations:
+
+* Jenkins build workers can run Docker on a variety of host operating systems and build for others
+* Anyone running Docker will be able to duplicate our build and packaging environments
+* Will allow us to build on existing container clusters instead of single purpose build VMs
+
+If building artifacts using Docker containers interests you check out the README in `deploy/packaging/docker`


### PR DESCRIPTION
This commit lays the groundwork for a multi-step transition from building GeoWave using customized Jenkins worker AMIs to using generic build nodes with just Docker and git installed #371  This is step one which will put in place the configuration needed to be able to build the containers and scripts to orchestrate the build.
