### PR TITLE
Update Boundless maven repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -657,7 +657,7 @@
 			</snapshots>
 			<id>boundlessgeo</id>
 			<name>BoundlessGeo Maven Repository</name>
-			<url>http://repo.boundlessgeo.com/main</url>
+			<url>https://boundless.artifactoryonline.com/boundless/main</url>
 		</repository>
 		<repository>
 			<id>osgeo</id>


### PR DESCRIPTION
Per their blog article at http://blog.geoserver.org/2015/09/29/new-repository-and-release-delay/ it looks like boundless has re-hosted their Maven repo.