### PR TITLE
Changed the featuretype for TRACK to LineString to allow the STANAG 4…

### DIFF
--- a/extensions/formats/stanag4676/format/src/main/java/mil/nga/giat/geowave/format/stanag4676/Stanag4676Utils.java
+++ b/extensions/formats/stanag4676/format/src/main/java/mil/nga/giat/geowave/format/stanag4676/Stanag4676Utils.java
@@ -7,6 +7,7 @@ import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
 import org.opengis.feature.simple.SimpleFeatureType;
 
 import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.geom.LineString;
 
 public class Stanag4676Utils
 {
@@ -136,7 +137,7 @@ public class Stanag4676Utils
 		final AttributeTypeBuilder attributeTypeBuilder = new AttributeTypeBuilder();
 
 		simpleFeatureTypeBuilder.add(attributeTypeBuilder.binding(
-				Geometry.class).buildDescriptor(
+				LineString.class).buildDescriptor(
 				"geometry"));
 		simpleFeatureTypeBuilder.add(attributeTypeBuilder.binding(
 				String.class).buildDescriptor(


### PR DESCRIPTION
…676 data to be scanned.

While scanning 4676 line featuretype data in Accumulo, the iterator throws an exception due to a bad CQL filter string.

This is where the error occurs:

https://github.com/geoserver/geoserver/blob/master/src/wms/src/main/java/org/geoserver/wms/featureinfo/FeatureInfoStylePreprocessor.java#L218

It is because the geometry is of binding class Geometry.class (rather than LineString.class) so being specific and using LineString.class on our ingest should be a reasonable workaround.