### PR TITLE
Addition of AvroFeatureAdapter

### DIFF
--- a/extensions/adapters/vector/pom.xml
+++ b/extensions/adapters/vector/pom.xml
@@ -86,4 +86,25 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+	<build>
+		<plugins>
+      		<plugin>
+        		<groupId>org.apache.avro</groupId>
+        		<artifactId>avro-maven-plugin</artifactId>
+        		<executions>
+          			<execution>
+            			<phase>generate-sources</phase>
+            			<goals>
+              				<goal>schema</goal>
+            			</goals>
+            			<configuration>
+              				<sourceDirectory>${project.basedir}/src/main/avro/</sourceDirectory>
+              				<outputDirectory>${project.basedir}/src/main/java/</outputDirectory>
+              				<stringType>String</stringType>
+            			</configuration>
+          			</execution>
+        		</executions>
+      		</plugin>
+    	</plugins>
+	</build>
 </project>

--- a/extensions/adapters/vector/src/main/avro/AvroSimpleFeature.avsc
+++ b/extensions/adapters/vector/src/main/avro/AvroSimpleFeature.avsc
@@ -1,0 +1,76 @@
+[
+    {
+        "name" : "AttributeValue",
+        "namespace" : "mil.nga.giat.geowave.adapter.vector.simpleFeature.avro",
+        "type" : "record",
+        "fields" : [
+            {
+            	"name" : "fid",
+                "type" : "string"
+            },
+            {
+             	 "name" : "values",
+                 "type" : {
+                     "type" : "array",
+                     "items" : "bytes"
+                 }
+            },
+            {
+            	"name" : "classifications",
+                "type" : [
+                    "null",{
+                        "type" : "array",
+                        "items" : "string"
+                    }
+                ]
+            }
+         ]
+    },
+    {
+        "name" : "FeatureDefinition",
+        "namespace" : "mil.nga.giat.geowave.adapter.vector.simpleFeature.avro",
+        "type" : "record",
+        "fields" : [
+             {
+             	"name" : "featureTypeName",
+             	"type" : "string"
+             },
+             {
+             	 "name" : "attributeNames",
+                 "type" : {
+                     "type" : "array",
+                     "items" : "string"
+                 }
+             },
+             {
+             	 "name" : "attributeTypes",
+                 "type" : {
+                     "type" : "array",
+                     "items" : "string"
+             	 }
+             },
+             {
+             	 "name" : "attributeDefaultClassifications",
+                 "type" : {
+                     "type" : "array",
+                     "items" : "string"
+             	 }
+             }
+         ]
+    },
+    {
+        "name" : "AvroSimpleFeature",
+        "namespace" : "mil.nga.giat.geowave.adapter.vector.simpleFeature.avro",
+        "type" : "record",
+        "fields" : [
+            {
+            	"name" : "featureType",
+            	"type" : "FeatureDefinition"
+           	},
+            {
+            	"name" : "value",
+            	"type" : "AttributeValue"
+            }
+        ]
+    }
+]

--- a/extensions/adapters/vector/src/main/java/mil/nga/giat/geowave/adapter/vector/AvroAttributeRowBuilder.java
+++ b/extensions/adapters/vector/src/main/java/mil/nga/giat/geowave/adapter/vector/AvroAttributeRowBuilder.java
@@ -1,0 +1,39 @@
+package mil.nga.giat.geowave.adapter.vector;
+
+import mil.nga.giat.geowave.core.index.ByteArrayId;
+import mil.nga.giat.geowave.core.store.adapter.NativeFieldHandler.RowBuilder;
+import mil.nga.giat.geowave.core.store.data.PersistentValue;
+
+import org.opengis.feature.simple.SimpleFeature;
+
+/**
+ * A GeoWave RowBuilder, used internally by AbstractDataAdapter to construct
+ * rows from a set field values (in this case SimpleFeatures from a set of
+ * attribute values). This implementation simply wraps a geotools
+ * SimpleFeatureBuilder.
+ * 
+ */
+public class AvroAttributeRowBuilder implements
+		RowBuilder<SimpleFeature, Object>
+{
+	private Object object;
+
+	public AvroAttributeRowBuilder() {}
+
+	@Override
+	public SimpleFeature buildRow(
+			final ByteArrayId dataId ) {
+		SimpleFeature sf = (SimpleFeature) object;
+		return sf;
+	}
+
+	@Override
+	public void setField(
+			final PersistentValue<Object> fieldValue ) {
+		// Only interested in the relevant fields
+		if (fieldValue.getId().equals(
+				AvroFeatureAttributeHandler.FIELD_ID)) {
+			object = fieldValue.getValue();
+		}
+	}
+}

--- a/extensions/adapters/vector/src/main/java/mil/nga/giat/geowave/adapter/vector/AvroFeatureAttributeHandler.java
+++ b/extensions/adapters/vector/src/main/java/mil/nga/giat/geowave/adapter/vector/AvroFeatureAttributeHandler.java
@@ -1,0 +1,31 @@
+package mil.nga.giat.geowave.adapter.vector;
+
+import mil.nga.giat.geowave.core.index.ByteArrayId;
+import mil.nga.giat.geowave.core.store.adapter.NativeFieldHandler;
+
+import org.opengis.feature.simple.SimpleFeature;
+
+/**
+ * This is used by the FeatureDataAdapter to handle GeoWave 'fields' using
+ * SimpleFeature 'attributes.'
+ * 
+ */
+public class AvroFeatureAttributeHandler implements
+		NativeFieldHandler<SimpleFeature, Object>
+{
+	public static final ByteArrayId FIELD_ID = new ByteArrayId(
+			"foo");
+
+	public AvroFeatureAttributeHandler() {}
+
+	@Override
+	public ByteArrayId getFieldId() {
+		return FIELD_ID;
+	}
+
+	@Override
+	public Object getFieldValue(
+			final SimpleFeature row ) {
+		return row;
+	}
+}

--- a/extensions/adapters/vector/src/main/java/mil/nga/giat/geowave/adapter/vector/AvroFeatureDataAdapter.java
+++ b/extensions/adapters/vector/src/main/java/mil/nga/giat/geowave/adapter/vector/AvroFeatureDataAdapter.java
@@ -1,0 +1,91 @@
+package mil.nga.giat.geowave.adapter.vector;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import mil.nga.giat.geowave.adapter.vector.plugin.visibility.JsonDefinitionColumnVisibilityManagement;
+import mil.nga.giat.geowave.core.index.ByteArrayId;
+import mil.nga.giat.geowave.core.store.adapter.NativeFieldHandler;
+import mil.nga.giat.geowave.core.store.adapter.NativeFieldHandler.RowBuilder;
+import mil.nga.giat.geowave.core.store.adapter.PersistentIndexFieldHandler;
+import mil.nga.giat.geowave.core.store.data.field.FieldReader;
+import mil.nga.giat.geowave.core.store.data.field.FieldVisibilityHandler;
+import mil.nga.giat.geowave.core.store.data.field.FieldWriter;
+import mil.nga.giat.geowave.core.store.data.visibility.VisibilityManagement;
+import mil.nga.giat.geowave.core.store.index.CommonIndexValue;
+
+import org.opengis.feature.simple.SimpleFeature;
+import org.opengis.feature.simple.SimpleFeatureType;
+
+/**
+ */
+public class AvroFeatureDataAdapter extends
+		FeatureDataAdapter
+{
+
+	protected AvroFeatureDataAdapter() {}
+
+	public AvroFeatureDataAdapter(
+			final SimpleFeatureType type ) {
+		super(
+				type,
+				new ArrayList<PersistentIndexFieldHandler<SimpleFeature, ? extends CommonIndexValue, Object>>());
+	}
+
+	public AvroFeatureDataAdapter(
+			final SimpleFeatureType type,
+			final VisibilityManagement<SimpleFeature> visibilityManagement ) {
+		super(
+				type,
+				new ArrayList<PersistentIndexFieldHandler<SimpleFeature, ? extends CommonIndexValue, Object>>(),
+				null,
+				visibilityManagement);
+	}
+
+	public AvroFeatureDataAdapter(
+			final SimpleFeatureType type,
+			final List<PersistentIndexFieldHandler<SimpleFeature, ? extends CommonIndexValue, Object>> customIndexHandlers ) {
+		super(
+				type,
+				customIndexHandlers,
+				null,
+				new JsonDefinitionColumnVisibilityManagement<SimpleFeature>());
+	}
+
+	public AvroFeatureDataAdapter(
+			final SimpleFeatureType type,
+			final FieldVisibilityHandler<SimpleFeature, Object> fieldVisiblityHandler ) {
+		super(
+				type,
+				new ArrayList<PersistentIndexFieldHandler<SimpleFeature, ? extends CommonIndexValue, Object>>(),
+				fieldVisiblityHandler,
+				new JsonDefinitionColumnVisibilityManagement<SimpleFeature>());
+	}
+
+	@Override
+	protected List<NativeFieldHandler<SimpleFeature, Object>> typeToFieldHandlers(
+			final SimpleFeatureType type ) {
+		final List<NativeFieldHandler<SimpleFeature, Object>> nativeHandlers = new ArrayList<NativeFieldHandler<SimpleFeature, Object>>(
+				1);
+
+		nativeHandlers.add(new AvroFeatureAttributeHandler());
+		return nativeHandlers;
+	}
+
+	@Override
+	public FieldReader<Object> getReader(
+			final ByteArrayId fieldId ) {
+		return (FieldReader<Object>) new AvroFeatureReader();
+	}
+
+	@Override
+	public FieldWriter<SimpleFeature, Object> getWriter(
+			final ByteArrayId fieldId ) {
+		return (FieldWriter<SimpleFeature, Object>) new AvroFeatureWriter();
+	}
+
+	@Override
+	protected RowBuilder<SimpleFeature, Object> newBuilder() {
+		return new AvroAttributeRowBuilder();
+	}
+}

--- a/extensions/adapters/vector/src/main/java/mil/nga/giat/geowave/adapter/vector/AvroFeatureReader.java
+++ b/extensions/adapters/vector/src/main/java/mil/nga/giat/geowave/adapter/vector/AvroFeatureReader.java
@@ -1,0 +1,145 @@
+package mil.nga.giat.geowave.adapter.vector;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.List;
+
+import mil.nga.giat.geowave.adapter.vector.plugin.GeoWaveGTDataStore;
+import mil.nga.giat.geowave.adapter.vector.simpleFeature.avro.AttributeValue;
+import mil.nga.giat.geowave.adapter.vector.simpleFeature.avro.AvroSimpleFeature;
+import mil.nga.giat.geowave.core.store.data.field.FieldReader;
+import mil.nga.giat.geowave.core.store.data.field.FieldUtils;
+
+import org.apache.avro.io.BinaryDecoder;
+import org.apache.avro.io.DecoderFactory;
+import org.apache.avro.specific.SpecificDatumReader;
+import org.apache.log4j.Logger;
+import org.geotools.feature.simple.SimpleFeatureBuilder;
+import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
+import org.opengis.feature.simple.SimpleFeature;
+import org.opengis.feature.simple.SimpleFeatureType;
+
+import com.google.common.base.Preconditions;
+import com.vividsolutions.jts.io.ParseException;
+import com.vividsolutions.jts.io.WKBReader;
+
+public class AvroFeatureReader implements
+		FieldReader<Object>
+{
+	private final static Logger LOGGER = Logger.getLogger(AvroFeatureReader.class);
+
+	private final DecoderFactory df = DecoderFactory.get();
+	private final SpecificDatumReader<AvroSimpleFeature> datumReader = new SpecificDatumReader<AvroSimpleFeature>();
+	private final WKBReader wkbReader = new WKBReader();
+
+	@Override
+	public Object readField(
+			final byte[] fieldData ) {
+		SimpleFeature deserializedSimpleFeature = null;
+		try {
+			deserializedSimpleFeature = deserializeAvroSimpleFeature(fieldData);
+		}
+		catch (Exception e) {
+			LOGGER.error(
+					"Unable to deserialize SimpleFeature",
+					e);
+		}
+
+		return deserializedSimpleFeature;
+	}
+
+	// Deserialization logic
+
+	/***
+	 * Deserialize byte stream into an AvroSimpleFeature
+	 * 
+	 * @param avroData
+	 *            serialized bytes of AvroSimpleFeature
+	 * @param avroObjectToReuse
+	 *            null or AvroSimpleFeature instance to be re-used. If null a
+	 *            new object will be allocated.
+	 * @return instance of AvroSimpleFeature with values parsed from avroData
+	 * @throws IOException
+	 */
+	private AvroSimpleFeature deserializeASF(
+			final byte[] avroData,
+			AvroSimpleFeature avroObjectToReuse )
+			throws IOException {
+		BinaryDecoder decoder = df.binaryDecoder(
+				avroData,
+				null);
+		if (avroObjectToReuse == null) {
+			avroObjectToReuse = new AvroSimpleFeature();
+		}
+
+		datumReader.setSchema(avroObjectToReuse.getSchema());
+		return datumReader.read(
+				avroObjectToReuse,
+				decoder);
+	}
+
+	/***
+	 * Deserialize byte array into an AvroSimpleFeature then convert to a
+	 * SimpleFeature
+	 * 
+	 * @param avroData
+	 *            serialized bytes of a AvroSimpleFeature
+	 * @return Collection of GeoTools SimpleFeature instances.
+	 * @throws IOException
+	 * @throws ClassNotFoundException
+	 * @throws ParseException
+	 */
+	public SimpleFeature deserializeAvroSimpleFeature(
+			final byte[] avroData )
+			throws IOException,
+			ClassNotFoundException,
+			ParseException {
+		// Deserialize
+		AvroSimpleFeature sfc = deserializeASF(
+				avroData,
+				null);
+
+		// Convert
+		SimpleFeature simpleFeature = null;
+
+		SimpleFeatureTypeBuilder sftb = new SimpleFeatureTypeBuilder();
+		sftb.setCRS(GeoWaveGTDataStore.DEFAULT_CRS);
+		sftb.setName(sfc.getFeatureType().getFeatureTypeName());
+		List<String> featureTypes = sfc.getFeatureType().getAttributeTypes();
+		List<String> featureNames = sfc.getFeatureType().getAttributeNames();
+		for (int i = 0; i < sfc.getFeatureType().getAttributeNames().size(); i++) {
+			String type = featureTypes.get(i);
+			String name = featureNames.get(i);
+			Class<?> c = Class.forName(type);
+			sftb.add(
+					name,
+					c);
+		}
+
+		SimpleFeatureType sft = sftb.buildFeatureType();
+		SimpleFeatureBuilder sfb = new SimpleFeatureBuilder(
+				sft);
+
+		AttributeValue attributeValue = sfc.getValue();
+
+		// null values should still take a place in the array - check
+		Preconditions.checkArgument(featureNames.size() == attributeValue.getValues().size());
+		for (int i = 0; i < attributeValue.getValues().size(); i++) {
+			ByteBuffer val = attributeValue.getValues().get(
+					i);
+
+			if (featureTypes.get(
+					i).equals(
+					"com.vividsolutions.jts.geom.Geometry")) {
+				sfb.add(wkbReader.read(val.array()));
+			}
+			else {
+				FieldReader<?> fr = FieldUtils.getDefaultReaderForClass(Class.forName(featureTypes.get(i)));
+				sfb.add(fr.readField(val.array()));
+			}
+		}
+
+		simpleFeature = sfb.buildFeature(attributeValue.getFid());
+		return simpleFeature;
+	}
+}

--- a/extensions/adapters/vector/src/main/java/mil/nga/giat/geowave/adapter/vector/AvroFeatureWriter.java
+++ b/extensions/adapters/vector/src/main/java/mil/nga/giat/geowave/adapter/vector/AvroFeatureWriter.java
@@ -1,0 +1,268 @@
+package mil.nga.giat.geowave.adapter.vector;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import mil.nga.giat.geowave.adapter.vector.simpleFeature.avro.AttributeValue;
+import mil.nga.giat.geowave.adapter.vector.simpleFeature.avro.AvroSimpleFeature;
+import mil.nga.giat.geowave.adapter.vector.simpleFeature.avro.FeatureDefinition;
+import mil.nga.giat.geowave.core.index.ByteArrayId;
+import mil.nga.giat.geowave.core.store.data.field.FieldUtils;
+import mil.nga.giat.geowave.core.store.data.field.FieldWriter;
+
+import org.apache.avro.io.BinaryEncoder;
+import org.apache.avro.io.EncoderFactory;
+import org.apache.avro.specific.SpecificDatumWriter;
+import org.apache.log4j.Logger;
+import org.opengis.feature.simple.SimpleFeature;
+import org.opengis.feature.simple.SimpleFeatureType;
+import org.opengis.feature.type.AttributeDescriptor;
+
+import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.io.WKBWriter;
+
+public class AvroFeatureWriter implements
+		FieldWriter<SimpleFeature, Object>
+{
+	private static final Logger LOGGER = Logger.getLogger(AvroFeatureWriter.class);
+
+	private final EncoderFactory ef = EncoderFactory.get();
+
+	private final SpecificDatumWriter<AvroSimpleFeature> datumWriter = new SpecificDatumWriter<AvroSimpleFeature>();
+	private final WKBWriter wkbWriter = new WKBWriter(
+			3);
+
+	@Override
+	public byte[] getVisibility(
+			final SimpleFeature rowValue,
+			final ByteArrayId fieldId,
+			final Object fieldValue ) {
+		return new byte[] {};
+	}
+
+	@Override
+	public byte[] writeField(
+			final Object fieldValue ) {
+		byte[] serializedAttributes = null;
+		try {
+			serializedAttributes = serializeAvroSimpleFeature(
+					(SimpleFeature) fieldValue,
+					null,
+					null,
+					"");
+		}
+		catch (IOException e) {
+			e.printStackTrace();
+			LOGGER.error(
+					"Error, failed to serialize SimpleFeature with id '" + ((SimpleFeature) fieldValue).getID() + "'",
+					e);
+		}
+
+		// there is no need to preface the payload with the class name and a
+		// length of the class name, the implementation is assumed to be known
+		// on read so we can save space on persistence
+		return serializedAttributes;
+	}
+
+	// Serialization logic
+
+	/***
+	 * @param avroObject
+	 *            Avro object to serialized
+	 * @return byte array of serialized avro data
+	 * @throws IOException
+	 */
+	private byte[] serializeAvroSimpleFeature(
+			final AvroSimpleFeature avroObject )
+			throws IOException {
+		ByteArrayOutputStream os = new ByteArrayOutputStream();
+		BinaryEncoder encoder = ef.binaryEncoder(
+				os,
+				null);
+		datumWriter.setSchema(avroObject.getSchema());
+		datumWriter.write(
+				avroObject,
+				encoder);
+		encoder.flush();
+		return os.toByteArray();
+	}
+
+	/***
+	 * Converts a SimpleFeature to an avroSimpleFeature and then serializes it.
+	 * 
+	 * @param sf
+	 *            Simple Feature to be serialized
+	 * @param avroObjectToReuse
+	 *            null or AvroSimpleFeature instance to be re-used. If null a
+	 *            new instance will be allocated
+	 * @param defaultClassifications
+	 *            null map of attribute names vs. classification. if null all
+	 *            values will be set to the default classification
+	 * @param defaultClassification
+	 *            null or default classification. if null and
+	 *            defaultClassifications are not provided an exception will be
+	 *            thrown
+	 * @return
+	 * @throws IOException
+	 */
+	public byte[] serializeAvroSimpleFeature(
+			SimpleFeature sf,
+			AvroSimpleFeature avroObjectToReuse,
+			Map<String, String> defaultClassifications,
+			String defaultClassification )
+			throws IOException {
+		if (sf == null) {
+			throw new IOException(
+					"Feature cannot be null");
+		}
+
+		if (defaultClassification == null && defaultClassifications == null) {
+			throw new IOException(
+					"if per attribute classifications aren't provided then a default classification must be provided");
+		}
+
+		SimpleFeatureType sft = sf.getType();
+		if (avroObjectToReuse == null) {
+			avroObjectToReuse = new AvroSimpleFeature();
+		}
+
+		FeatureDefinition fd = buildFeatureDefinition(
+				avroObjectToReuse.getFeatureType(),
+				sft,
+				defaultClassifications,
+				defaultClassification);
+		avroObjectToReuse.setFeatureType(fd);
+
+		AttributeValue av = buildAttributeValue(
+				sf,
+				sft);
+		avroObjectToReuse.setValue(av);
+
+		return serializeAvroSimpleFeature(avroObjectToReuse);
+	}
+
+	/**
+	 * Add the attributes, types and classifications for the SimpleFeatureType
+	 * to the provided FeatureDefinition
+	 * 
+	 * @param fd
+	 *            - existing Feature Definition (or new one if null)
+	 * @param sft
+	 *            - SimpleFeatureType of the simpleFeature being serialized
+	 * @param defaultClassifications
+	 *            - map of attribute names to classification
+	 * @param defaultClassification
+	 *            - default classification if one could not be found in the map
+	 * @return
+	 * @throws IOException
+	 */
+	private FeatureDefinition buildFeatureDefinition(
+			FeatureDefinition fd,
+			SimpleFeatureType sft,
+			Map<String, String> defaultClassifications,
+			String defaultClassification )
+			throws IOException {
+		if (fd == null) {
+			fd = new FeatureDefinition();
+		}
+		fd.setFeatureTypeName(sft.getTypeName());
+
+		List<String> attributes = new ArrayList<String>(
+				sft.getAttributeCount());
+		List<String> types = new ArrayList<String>(
+				sft.getAttributeCount());
+		List<String> classifications = new ArrayList<String>(
+				sft.getAttributeCount());
+
+		for (AttributeDescriptor attr : sft.getAttributeDescriptors()) {
+			String localName = attr.getLocalName();
+
+			attributes.add(localName);
+			types.add(attr.getType().getBinding().getCanonicalName());
+			classifications.add(getClassification(
+					localName,
+					defaultClassifications,
+					defaultClassification));
+		}
+
+		fd.setAttributeNames(attributes);
+		fd.setAttributeTypes(types);
+		fd.setAttributeDefaultClassifications(classifications);
+
+		return fd;
+	}
+
+	/**
+	 * If a classification exists for this attribute name then use it If not
+	 * then use the provided default classification
+	 * 
+	 * @param localName
+	 *            - attribute name
+	 * @param defaultClassifications
+	 *            - map of attribute names to classification
+	 * @param defaultClassification
+	 *            - default classification to use if one is not mapped for the
+	 *            name provided
+	 * @return
+	 * @throws IOException
+	 */
+	private String getClassification(
+			String localName,
+			Map<String, String> defaultClassifications,
+			String defaultClassification )
+			throws IOException {
+		String classification = null;
+
+		if (defaultClassifications != null && defaultClassifications.containsKey(localName)) {
+			classification = defaultClassifications.get(localName);
+		}
+		else {
+			classification = defaultClassification;
+		}
+
+		if (classification == null) {
+			throw new IOException(
+					"No default classification was provided, and no classification for: '" + localName + "' was provided");
+		}
+
+		return classification;
+	}
+
+	/**
+	 * Create an AttributeValue from the SimpleFeature's attributes
+	 * 
+	 * @param sf
+	 * @param sft
+	 * @return
+	 */
+	private AttributeValue buildAttributeValue(
+			SimpleFeature sf,
+			SimpleFeatureType sft ) {
+		AttributeValue attributeValue = new AttributeValue();
+
+		List<ByteBuffer> values = new ArrayList<ByteBuffer>(
+				sft.getAttributeCount());
+
+		attributeValue.setFid(sf.getID());
+
+		for (AttributeDescriptor attr : sft.getAttributeDescriptors()) {
+			Object o = sf.getAttribute(attr.getLocalName());
+			byte[] bytes = null;
+			if (o instanceof Geometry) {
+				bytes = wkbWriter.write((Geometry) o);
+			}
+			else {
+				FieldWriter fw = FieldUtils.getDefaultWriterForClass(attr.getType().getBinding());
+				bytes = fw.writeField(o);
+			}
+			values.add(ByteBuffer.wrap(bytes));
+		}
+		attributeValue.setValues(values);
+
+		return attributeValue;
+	}
+}

--- a/extensions/adapters/vector/src/main/java/mil/nga/giat/geowave/adapter/vector/FeatureDataAdapter.java
+++ b/extensions/adapters/vector/src/main/java/mil/nga/giat/geowave/adapter/vector/FeatureDataAdapter.java
@@ -8,8 +8,8 @@ import java.util.List;
 import mil.nga.giat.geowave.adapter.vector.plugin.GeoWaveGTDataStore;
 import mil.nga.giat.geowave.adapter.vector.plugin.visibility.AdaptorProxyFieldLevelVisibilityHandler;
 import mil.nga.giat.geowave.adapter.vector.plugin.visibility.JsonDefinitionColumnVisibilityManagement;
-import mil.nga.giat.geowave.adapter.vector.stats.StatsConfigurationCollection.SimpleFeatureStatsConfigurationCollection;
 import mil.nga.giat.geowave.adapter.vector.stats.StatsManager;
+import mil.nga.giat.geowave.adapter.vector.stats.StatsConfigurationCollection.SimpleFeatureStatsConfigurationCollection;
 import mil.nga.giat.geowave.adapter.vector.util.FeatureDataUtils;
 import mil.nga.giat.geowave.adapter.vector.utils.SimpleFeatureUserDataConfigurationSet;
 import mil.nga.giat.geowave.adapter.vector.utils.TimeDescriptors;
@@ -21,8 +21,8 @@ import mil.nga.giat.geowave.core.store.adapter.AbstractDataAdapter;
 import mil.nga.giat.geowave.core.store.adapter.AdapterPersistenceEncoding;
 import mil.nga.giat.geowave.core.store.adapter.IndexFieldHandler;
 import mil.nga.giat.geowave.core.store.adapter.NativeFieldHandler;
-import mil.nga.giat.geowave.core.store.adapter.NativeFieldHandler.RowBuilder;
 import mil.nga.giat.geowave.core.store.adapter.PersistentIndexFieldHandler;
+import mil.nga.giat.geowave.core.store.adapter.NativeFieldHandler.RowBuilder;
 import mil.nga.giat.geowave.core.store.adapter.statistics.DataStatistics;
 import mil.nga.giat.geowave.core.store.adapter.statistics.DataStatisticsVisibilityHandler;
 import mil.nga.giat.geowave.core.store.adapter.statistics.StatisticalDataAdapter;
@@ -90,13 +90,13 @@ import org.opengis.referencing.operation.MathTransform;
  * efficiency of query processing.
  * 
  */
-@SuppressWarnings("unchecked")
 public class FeatureDataAdapter extends
 		AbstractDataAdapter<SimpleFeature> implements
 		StatisticalDataAdapter<SimpleFeature>,
 		HadoopDataAdapter<SimpleFeature, FeatureWritable>
 {
 	private final static Logger LOGGER = Logger.getLogger(FeatureDataAdapter.class);
+
 	// the original coordinate system will always be represented internally by
 	// the persisted type
 	private SimpleFeatureType persistedType;
@@ -169,7 +169,7 @@ public class FeatureDataAdapter extends
 		fieldVisibilityManagement = visibilityManagement;
 	}
 
-	private void setFeatureType(
+	protected void setFeatureType(
 			final SimpleFeatureType type ) {
 		persistedType = type;
 		determineVisibilityAttribute();
@@ -202,7 +202,7 @@ public class FeatureDataAdapter extends
 				transform);
 	}
 
-	private static List<NativeFieldHandler<SimpleFeature, Object>> typeToFieldHandlers(
+	protected List<NativeFieldHandler<SimpleFeature, Object>> typeToFieldHandlers(
 			final SimpleFeatureType type ) {
 		final List<NativeFieldHandler<SimpleFeature, Object>> nativeHandlers = new ArrayList<NativeFieldHandler<SimpleFeature, Object>>(
 				type.getAttributeCount());
@@ -221,7 +221,7 @@ public class FeatureDataAdapter extends
 		return fieldVisibilityManagement;
 	}
 
-	private IndexFieldHandler<SimpleFeature, Time, Object> getTimeRangeHandler(
+	protected IndexFieldHandler<SimpleFeature, Time, Object> getTimeRangeHandler(
 			final SimpleFeatureType featureType ) {
 		final TimeDescriptors timeDescriptors = inferTimeAttributeDescriptor(featureType);
 		if ((timeDescriptors.getStartRange() != null) && (timeDescriptors.getEndRange() != null)) {
@@ -371,6 +371,7 @@ public class FeatureDataAdapter extends
 		return buf.array();
 	}
 
+	@SuppressWarnings("unchecked")
 	@Override
 	protected Object defaultTypeDataFromBinary(
 			final byte[] bytes ) {
@@ -493,7 +494,6 @@ public class FeatureDataAdapter extends
 	public AdapterPersistenceEncoding encode(
 			final SimpleFeature entry,
 			final CommonIndexModel indexModel ) {
-
 		return super.encode(
 				FeatureDataUtils.defaultCRSTransform(
 						entry,


### PR DESCRIPTION
This new adapter is intented to serialize all the attributes of a SimpleFeature as a single object.  This is meant as an optimization when visibility is the same for all attributes of the feature.
Included is the avro schema to create the generated classes from chris bennights Import/Export project, these are necessary for avro serializing/deserializing the SimpleFeature.