### PR TITLE
Invalid video info when no image chip is available

### DIFF
--- a/extensions/formats/stanag4676/format/src/main/java/mil/nga/giat/geowave/format/stanag4676/IngestMessageHandler.java
+++ b/extensions/formats/stanag4676/format/src/main/java/mil/nga/giat/geowave/format/stanag4676/IngestMessageHandler.java
@@ -111,16 +111,20 @@ public class IngestMessageHandler implements
 					int height = -1;
 					for (final MotionImagery imagery : images) {
 						try {
-							final byte[] binary = BaseEncoding.base64().decode(
-									imagery.getImageChip());
-							final ImageInputStream stream = ImageIO.createImageInputStream(new ByteArrayInputStream(
-									binary));
-							final BufferedImage img = ImageIO.read(stream);
-							if ((width < 0) || (img.getWidth() > width)) {
-								width = img.getWidth();
-							}
-							if ((height < 0) || (img.getHeight() > height)) {
-								height = img.getHeight();
+							String imageChip = imagery.getImageChip();
+							BufferedImage img = null;
+							if (imageChip != null && imageChip.length() > 0) {
+								final byte[] binary = BaseEncoding.base64().decode(
+										imageChip);
+								final ImageInputStream stream = ImageIO.createImageInputStream(new ByteArrayInputStream(
+										binary));
+								img = ImageIO.read(stream);
+								if ((width < 0) || (img.getWidth() > width)) {
+									width = img.getWidth();
+								}
+								if ((height < 0) || (img.getHeight() > height)) {
+									height = img.getHeight();
+								}
 							}
 							timesWithImageChips.put(
 									imagery.getTime(),
@@ -139,28 +143,29 @@ public class IngestMessageHandler implements
 
 					for (final Entry<Long, ImageChipInfo> chipInfo : timesWithImageChips.entrySet()) {
 						final BufferedImage img = chipInfo.getValue().getImage();
-
-						final BufferedImage scaledImage = toBufferedImage(
-								img.getScaledInstance(
-										width,
-										height,
-										Image.SCALE_SMOOTH),
-								BufferedImage.TYPE_3BYTE_BGR);
-						chipInfo.getValue().setImage(
-								scaledImage);
-						try (final ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
-							ImageIO.write(
-									scaledImage,
-									DEFAULT_IMAGE_FORMAT,
-									baos);
-							baos.flush();
-							chipInfo.getValue().setImageBytes(
-									baos.toByteArray());
-						}
-						catch (final Exception e) {
-							LOGGER.warn(
-									"Unable to write image chip to file",
-									e);
+						if (img != null) {
+							final BufferedImage scaledImage = toBufferedImage(
+									img.getScaledInstance(
+											width,
+											height,
+											Image.SCALE_SMOOTH),
+									BufferedImage.TYPE_3BYTE_BGR);
+							chipInfo.getValue().setImage(
+									scaledImage);
+							try (final ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+								ImageIO.write(
+										scaledImage,
+										DEFAULT_IMAGE_FORMAT,
+										baos);
+								baos.flush();
+								chipInfo.getValue().setImageBytes(
+										baos.toByteArray());
+							}
+							catch (final Exception e) {
+								LOGGER.warn(
+										"Unable to write image chip to file",
+										e);
+							}
 						}
 					}
 

--- a/extensions/formats/stanag4676/format/src/main/java/mil/nga/giat/geowave/format/stanag4676/Stanag4676EventWritable.java
+++ b/extensions/formats/stanag4676/format/src/main/java/mil/nga/giat/geowave/format/stanag4676/Stanag4676EventWritable.java
@@ -164,8 +164,10 @@ public class Stanag4676EventWritable implements
 				0);
 		Geometry = new BytesWritable(
 				geometry);
-		Image = new BytesWritable(
-				image);
+		if (image != null) {
+			Image = new BytesWritable(
+					image);
+		}
 		MissionUUID = new Text(
 				missionUUID);
 		TrackNumber = new Text(
@@ -230,8 +232,11 @@ public class Stanag4676EventWritable implements
 				1);
 		Geometry = new BytesWritable(
 				geometry);
-		Image = new BytesWritable(
-				image);
+		if (image != null) {
+			Image = new BytesWritable(
+					image);
+		}
+
 		MissionUUID = new Text(
 				missionUUID);
 		TrackNumber = new Text(


### PR DESCRIPTION
This pull request fixes an issue with a track point's video info (pixel column, pixel row and frame number) when an image chip is not available.

Prior to this fix, none of the video information for a track point or motion point was being populated if an image chip was not available. The pixel row, pixel col and frame number was being stored in GeoWave as -1.

An NPE was being thrown and caught when the imageChip was not populated causing the population of the other fields to be bypassed.