### PR TITLE
Doc and deployment script fixes for EMR bootstrap failures

### DIFF
--- a/deploy/emr/4/bootstrap-geowave.sh
+++ b/deploy/emr/4/bootstrap-geowave.sh
@@ -16,9 +16,10 @@ USER=accumulo
 # EMR at any point after creation so the password set during the initial spin-up would have
 # to be persisted somewhere and provided to the newly created nodes at some later date.
 USERPW=secret # TODO: Can't change until trace.password in accumulo-site.xml is updated
-ACCUMULO_VERSION=1.6.4
+ACCUMULO_VERSION=1.7.0
 ACCUMULO_TSERVER_OPTS=3GB
 INSTALL_DIR=/opt
+ACCUMULO_DOWNLOAD_BASE_URL=https://archive.apache.org/dist/accumulo
 
 # GeoWave
 GEOWAVE_REPO_RPM=geowave-repo-dev-1.0-3.noarch.rpm # TODO: Should have a prod->latest rpm

--- a/deploy/emr/4/geowave-install-lib.sh
+++ b/deploy/emr/4/geowave-install-lib.sh
@@ -59,9 +59,8 @@ with_backoff() {
 # Using zookeeper packaged by Apache BigTop for ease of installation
 configure_zookeeper() {
 	if is_master ; then
-		sudo sh -c "curl http://www.apache.org/dist/bigtop/bigtop-1.0.0/repos/centos6/bigtop.repo > /etc/yum.repos.d/bigtop.repo"
-		sudo yum -y install zookeeper-server
-		sudo service zookeeper-server start # EMR uses Amazon Linux which uses Upstart
+		sudo yum -y install zookeeper-server # EMR 4.3.0 includes Apache Bigtop.repo config
+		sudo initctl start zookeeper-server  # EMR uses Amazon Linux which uses Upstart
 		# Zookeeper installed on this node, record internal ip from instance metadata
 		ZK_IPADDR=$(curl http://169.254.169.254/latest/meta-data/local-ipv4)
 	else
@@ -115,7 +114,7 @@ install_accumulo() {
 	wait_until_hdfs_is_available
 	ARCHIVE_FILE="accumulo-${ACCUMULO_VERSION}-bin.tar.gz"
 	LOCAL_ARCHIVE="${INSTALL_DIR}/${ARCHIVE_FILE}"
-	sudo sh -c "curl 'http://apache.mirrors.tds.net/accumulo/${ACCUMULO_VERSION}/${ARCHIVE_FILE}' > $LOCAL_ARCHIVE"
+	sudo sh -c "curl '${ACCUMULO_DOWNLOAD_BASE_URL}/${ACCUMULO_VERSION}/${ARCHIVE_FILE}' > $LOCAL_ARCHIVE"
 	sudo sh -c "tar xzf $LOCAL_ARCHIVE -C $INSTALL_DIR"
 	sudo rm -f $LOCAL_ARCHIVE
 	sudo ln -s "${INSTALL_DIR}/accumulo-${ACCUMULO_VERSION}" "${INSTALL_DIR}/accumulo"

--- a/docs/content/081-running-from-emr.adoc
+++ b/docs/content/081-running-from-emr.adoc
@@ -28,7 +28,7 @@ aws emr create-cluster \
   --instance-groups InstanceGroupType=MASTER,InstanceCount=1,InstanceType=m3.xlarge InstanceGroupType=CORE,InstanceCount=${NUM_WORKERS},InstanceType=m3.xlarge \
   --ec2-attributes "KeyName=YOUR_KEYNAME,SubnetId=YOUR_SUBNET_ID" \
   --region YOUR_REGION \
-  --release-label emr-4.2.0 \
+  --release-label emr-4.3.0 \
   --applications Name=Ganglia Name=Hadoop Name=Hue Name=Spark \
   --use-default-roles \
   --no-auto-terminate \


### PR DESCRIPTION
This request contains fixes for #633, "GeoWave on EMR Fails During Bootstrap".  Copies of these files have already been placed in the GeoWave S3 bucket used by the Jenkins EMR launch script.

The first problem was http://apache.mirrors.tds.net/accumulo/ removed all of the Accumulo binary archive files except for the recently released 1.6.5 and 1.7.0 and we defaulted to 1.6.4 To fix I made ACCUMULO_DOWNLOAD_BASE_URL a setting that defaults to https://archive.apache.org/dist/accumulo which has both recent and past releases. We could also vendor our own copies somewhere else if artifacts disappearing or moving continues to be a problem.

The second problem was the URL to the RPM GPG signing key for the Apache BigTop repo was recently moved and the repo file I was curling into /etc/yum.repos.d still listed the old version so zookeeper was not getting installed causing Accumulo to error out during install and the whole cluster would get terminated.

While looking into this problem I noticed Amazon recently put out a new version of EMR v4.3.0 which includes a bundled version of the BigTop repo. So the fix was to just use the repo included in the newer version of EMR.

**Version upgrades in EMR 4.3.0**

From: http://docs.aws.amazon.com/ElasticMapReduce/latest/ReleaseGuide/emr-whatsnew.html

* Upgraded to Hadoop 2.7.1
* Upgraded to Spark 1.6.0
* Upgraded Ganglia to 3.7.2
* Upgraded Presto to 0.130

I tested that the cluster would start as expected with the newly released Accumulo 1.6.5 and Accumulo 1.7.0 but didn't do any extensive testing with GeoWave to validate.