### PR TITLE
Geowave 615

### DIFF
--- a/core/store/src/main/java/mil/nga/giat/geowave/core/store/query/QueryOptions.java
+++ b/core/store/src/main/java/mil/nga/giat/geowave/core/store/query/QueryOptions.java
@@ -55,7 +55,7 @@ public class QueryOptions implements
 	/**
 	 *
 	 */
-	private static final long serialVersionUID = 544085046847603372L;
+	private static final long serialVersionUID = 544085046847603371L;
 
 	private static ScanCallback<Object> DEFAULT_CALLBACK = new ScanCallback<Object>() {
 		@Override
@@ -82,6 +82,7 @@ public class QueryOptions implements
 	private transient ScanCallback<?> scanCallback = DEFAULT_CALLBACK;
 	private String[] authorizations = new String[0];
 	private Boolean dedupAcrossIndices = null;
+	private List<String> fieldIds = Collections.emptyList();
 
 	public QueryOptions(
 			final ByteArrayId adapterId,
@@ -159,6 +160,17 @@ public class QueryOptions implements
 		setLimit(limit);
 		this.scanCallback = scanCallback;
 		this.authorizations = authorizations;
+	}
+
+	/**
+	 * 
+	 * @param fieldIds
+	 *            the subset of fieldIds to be included with each query result
+	 */
+	public QueryOptions(
+			final List<String> fieldIds ) {
+		super();
+		this.fieldIds = fieldIds;
 	}
 
 	public QueryOptions() {}
@@ -357,8 +369,24 @@ public class QueryOptions implements
 		return ids;
 	}
 
-	public static long getSerialversionuid() {
-		return serialVersionUID;
+	/**
+	 * 
+	 * @return the fieldIds
+	 */
+	public List<String> getFieldIds() {
+		return fieldIds;
+	}
+
+	/**
+	 * 
+	 * @param fieldIds
+	 *            the desired subset of fieldIds to be included in query results
+	 */
+	public void setFieldIds(
+			final List<String> fieldIds ) {
+		if (fieldIds != null) {
+			this.fieldIds = fieldIds;
+		}
 	}
 
 	@Override
@@ -379,7 +407,27 @@ public class QueryOptions implements
 			}
 		}
 
-		final ByteBuffer buf = ByteBuffer.allocate(16 + authBytes.length + aSize + iSize);
+		int fieldIdsBytesNeeded = 0;
+		byte[] fieldIdsBytes = null;
+		if (fieldIds != null && fieldIds.size() > 0) {
+			final StringBuffer sBuf = new StringBuffer();
+			final String comma = ",";
+			for (String fieldId : fieldIds) {
+				if (sBuf.length() > 0) {
+					sBuf.append(comma);
+				}
+				sBuf.append(fieldId);
+			}
+			fieldIdsBytes = StringUtils.stringToBinary(sBuf.toString());
+			fieldIdsBytesNeeded = 4 + fieldIdsBytes.length;
+		}
+
+		final ByteBuffer buf = ByteBuffer.allocate(20 + authBytes.length + aSize + iSize + fieldIdsBytesNeeded);
+		buf.putInt((fieldIdsBytesNeeded > 0) ? 1 : 0);
+		if (fieldIdsBytesNeeded > 0) {
+			buf.putInt(fieldIdsBytes.length);
+			buf.put(fieldIdsBytes);
+		}
 
 		buf.putInt(dedupAcrossIndices == null ? -1 : (dedupAcrossIndices ? 1 : 0));
 		buf.putInt(authBytes.length);
@@ -411,6 +459,14 @@ public class QueryOptions implements
 			final byte[] bytes ) {
 
 		final ByteBuffer buf = ByteBuffer.wrap(bytes);
+		if (buf.getInt() == 1) {
+			final int fieldIdsLength = buf.getInt();
+			final byte[] fieldIdsBytes = new byte[fieldIdsLength];
+			buf.get(fieldIdsBytes);
+			fieldIds = Arrays.asList(StringUtils.stringFromBinary(
+					fieldIdsBytes).split(
+					","));
+		}
 		final int dedupCode = buf.getInt();
 
 		dedupAcrossIndices = null;

--- a/core/store/src/main/java/mil/nga/giat/geowave/core/store/query/QueryOptions.java
+++ b/core/store/src/main/java/mil/nga/giat/geowave/core/store/query/QueryOptions.java
@@ -407,25 +407,17 @@ public class QueryOptions implements
 			}
 		}
 
-		int fieldIdsBytesNeeded = 0;
-		byte[] fieldIdsBytes = null;
+		byte[] fieldIdsBytes = new byte[0];
 		if (fieldIds != null && fieldIds.size() > 0) {
-			final StringBuffer sBuf = new StringBuffer();
-			final String comma = ",";
-			for (String fieldId : fieldIds) {
-				if (sBuf.length() > 0) {
-					sBuf.append(comma);
-				}
-				sBuf.append(fieldId);
-			}
-			fieldIdsBytes = StringUtils.stringToBinary(sBuf.toString());
-			fieldIdsBytesNeeded = 4 + fieldIdsBytes.length;
+			final String fieldIdsString = org.apache.commons.lang3.StringUtils.join(
+					fieldIds,
+					',');
+			fieldIdsBytes = StringUtils.stringToBinary(fieldIdsString.toString());
 		}
 
-		final ByteBuffer buf = ByteBuffer.allocate(20 + authBytes.length + aSize + iSize + fieldIdsBytesNeeded);
-		buf.putInt((fieldIdsBytesNeeded > 0) ? 1 : 0);
-		if (fieldIdsBytesNeeded > 0) {
-			buf.putInt(fieldIdsBytes.length);
+		final ByteBuffer buf = ByteBuffer.allocate(20 + authBytes.length + aSize + iSize + fieldIdsBytes.length);
+		buf.putInt(fieldIdsBytes.length);
+		if (fieldIdsBytes.length > 0) {
 			buf.put(fieldIdsBytes);
 		}
 
@@ -459,8 +451,8 @@ public class QueryOptions implements
 			final byte[] bytes ) {
 
 		final ByteBuffer buf = ByteBuffer.wrap(bytes);
-		if (buf.getInt() == 1) {
-			final int fieldIdsLength = buf.getInt();
+		final int fieldIdsLength = buf.getInt();
+		if (fieldIdsLength > 0) {
 			final byte[] fieldIdsBytes = new byte[fieldIdsLength];
 			buf.get(fieldIdsBytes);
 			fieldIds = Arrays.asList(StringUtils.stringFromBinary(

--- a/core/store/src/test/java/mil/nga/giat/geowave/core/store/query/QueryOptionsTest.java
+++ b/core/store/src/test/java/mil/nga/giat/geowave/core/store/query/QueryOptionsTest.java
@@ -6,14 +6,16 @@ import static org.junit.Assert.assertTrue;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
-
-import org.junit.Test;
+import java.util.List;
 
 import mil.nga.giat.geowave.core.index.ByteArrayId;
 import mil.nga.giat.geowave.core.store.CloseableIterator;
 import mil.nga.giat.geowave.core.store.adapter.AdapterStore;
 import mil.nga.giat.geowave.core.store.adapter.DataAdapter;
 import mil.nga.giat.geowave.core.store.adapter.MockComponents;
+
+import org.junit.Assert;
+import org.junit.Test;
 
 public class QueryOptionsTest
 {
@@ -122,5 +124,20 @@ public class QueryOptionsTest
 				ops2.getAdapterIds(
 						adapterStore).size());
 
+	}
+
+	@Test
+	public void testFieldIdSerialization() {
+		final List<String> fieldIds = Arrays.asList(new String[] {
+			"one",
+			"two",
+			"three"
+		});
+		final QueryOptions ops = new QueryOptions(
+				fieldIds);
+		final QueryOptions deserialized = new QueryOptions();
+		deserialized.fromBinary(ops.toBinary());
+		Assert.assertTrue(fieldIds.size() == deserialized.getFieldIds().size());
+		Assert.assertTrue(fieldIds.equals(deserialized.getFieldIds()));
 	}
 }

--- a/extensions/adapters/vector/src/test/java/mil/nga/giat/geowave/adapter/vector/plugin/GeoToolsAttributesSubsetTest.java
+++ b/extensions/adapters/vector/src/test/java/mil/nga/giat/geowave/adapter/vector/plugin/GeoToolsAttributesSubsetTest.java
@@ -1,0 +1,147 @@
+package mil.nga.giat.geowave.adapter.vector.plugin;
+
+import static org.junit.Assert.assertFalse;
+
+import java.io.IOException;
+
+import mil.nga.giat.geowave.adapter.vector.BaseDataStoreTest;
+import mil.nga.giat.geowave.core.geotime.GeometryUtils;
+
+import org.geotools.data.DataStore;
+import org.geotools.data.DataUtilities;
+import org.geotools.data.DefaultTransaction;
+import org.geotools.data.FeatureReader;
+import org.geotools.data.FeatureWriter;
+import org.geotools.data.Query;
+import org.geotools.data.Transaction;
+import org.geotools.feature.SchemaException;
+import org.geotools.filter.text.cql2.CQL;
+import org.geotools.filter.text.cql2.CQLException;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.opengis.feature.simple.SimpleFeature;
+import org.opengis.feature.simple.SimpleFeatureType;
+
+import com.vividsolutions.jts.geom.Coordinate;
+
+public class GeoToolsAttributesSubsetTest extends
+		BaseDataStoreTest
+{
+	private DataStore geotoolsDataStore;
+	private SimpleFeatureType type;
+	private static final String typeName = "testStuff";
+	private static final String typeSpec = "geometry:Geometry:srid=4326,aLong:java.lang.Long,aString:String";
+	private static final String cqlPredicate = "BBOX(geometry,40,40,42,42)";
+	private static final String geometry_attribute = "geometry";
+	private static final String long_attribute = "aLong";
+	private static final String string_attribute = "aString";
+
+	@Before
+	public void setup()
+			throws IOException,
+			GeoWavePluginException,
+			SchemaException {
+		geotoolsDataStore = createDataStore();
+		type = DataUtilities.createType(
+				typeName,
+				typeSpec);
+
+		geotoolsDataStore.createSchema(type);
+		final Transaction transaction = new DefaultTransaction();
+		final FeatureWriter<SimpleFeatureType, SimpleFeature> writer = geotoolsDataStore.getFeatureWriter(
+				type.getTypeName(),
+				transaction);
+		assertFalse(writer.hasNext());
+		SimpleFeature newFeature = writer.next();
+		newFeature.setAttribute(
+				geometry_attribute,
+				GeometryUtils.GEOMETRY_FACTORY.createPoint(new Coordinate(
+						41.25,
+						41.25)));
+		newFeature.setAttribute(
+				long_attribute,
+				1l);
+		newFeature.setAttribute(
+				string_attribute,
+				"string1");
+		writer.write();
+		newFeature = writer.next();
+		newFeature.setAttribute(
+				geometry_attribute,
+				GeometryUtils.GEOMETRY_FACTORY.createPoint(new Coordinate(
+						41.5,
+						41.5)));
+		newFeature.setAttribute(
+				long_attribute,
+				2l);
+		newFeature.setAttribute(
+				string_attribute,
+				"string2");
+		writer.write();
+		newFeature = writer.next();
+		newFeature.setAttribute(
+				geometry_attribute,
+				GeometryUtils.GEOMETRY_FACTORY.createPoint(new Coordinate(
+						41.75,
+						41.75)));
+		newFeature.setAttribute(
+				long_attribute,
+				3l);
+		newFeature.setAttribute(
+				string_attribute,
+				"string3");
+		writer.write();
+		writer.close();
+		transaction.commit();
+		transaction.close();
+	}
+
+	@Test
+	public void testAllAttributes()
+			throws CQLException,
+			IOException {
+		final Query query = new Query(
+				typeName,
+				CQL.toFilter(cqlPredicate),
+				Query.ALL_PROPERTIES);
+		final FeatureReader<SimpleFeatureType, SimpleFeature> reader = geotoolsDataStore.getFeatureReader(
+				query,
+				Transaction.AUTO_COMMIT);
+		int count = 0;
+		while (reader.hasNext()) {
+			final SimpleFeature feature = reader.next();
+			count++;
+			Assert.assertTrue(feature.getAttribute(geometry_attribute) != null);
+			Assert.assertTrue(feature.getAttribute(long_attribute) != null);
+			Assert.assertTrue(feature.getAttribute(string_attribute) != null);
+		}
+		Assert.assertTrue(count == 3);
+	}
+
+	@Test
+	public void testSubsetAttributes()
+			throws CQLException,
+			IOException {
+		final Query query = new Query(
+				typeName,
+				CQL.toFilter(cqlPredicate),
+				new String[] {
+					geometry_attribute,
+					string_attribute
+				});
+		final FeatureReader<SimpleFeatureType, SimpleFeature> reader = geotoolsDataStore.getFeatureReader(
+				query,
+				Transaction.AUTO_COMMIT);
+		int count = 0;
+		while (reader.hasNext()) {
+			final SimpleFeature feature = reader.next();
+			count++;
+			Assert.assertTrue(feature.getAttribute(geometry_attribute) != null);
+			Assert.assertTrue(feature.getAttribute(long_attribute) == null);
+			Assert.assertTrue(feature.getAttribute(string_attribute) != null);
+		}
+		Assert.assertTrue(count == 3);
+	}
+
+}

--- a/extensions/datastores/accumulo/src/main/java/mil/nga/giat/geowave/datastore/accumulo/AccumuloDataStore.java
+++ b/extensions/datastores/accumulo/src/main/java/mil/nga/giat/geowave/datastore/accumulo/AccumuloDataStore.java
@@ -50,6 +50,7 @@ import mil.nga.giat.geowave.datastore.accumulo.metadata.AccumuloIndexStore;
 import mil.nga.giat.geowave.datastore.accumulo.query.AccumuloConstraintsQuery;
 import mil.nga.giat.geowave.datastore.accumulo.query.AccumuloRowIdsQuery;
 import mil.nga.giat.geowave.datastore.accumulo.query.AccumuloRowPrefixQuery;
+import mil.nga.giat.geowave.datastore.accumulo.query.SharedVisibilitySplittingIterator;
 import mil.nga.giat.geowave.datastore.accumulo.query.SingleEntryFilterIterator;
 import mil.nga.giat.geowave.datastore.accumulo.util.AccumuloUtils;
 import mil.nga.giat.geowave.datastore.accumulo.util.EntryIteratorWrapper;
@@ -492,6 +493,11 @@ public class AccumuloDataStore implements
 
 			scanner.fetchColumnFamily(new Text(
 					adapterId.getBytes()));
+			
+			scanner.addScanIterator(new IteratorSetting(
+					SharedVisibilitySplittingIterator.ITERATOR_PRIORITY,
+					SharedVisibilitySplittingIterator.ITERATOR_NAME,
+					SharedVisibilitySplittingIterator.class));
 
 			final IteratorSetting rowIteratorSettings = new IteratorSetting(
 					SingleEntryFilterIterator.WHOLE_ROW_ITERATOR_PRIORITY,

--- a/extensions/datastores/accumulo/src/main/java/mil/nga/giat/geowave/datastore/accumulo/AccumuloDataStore.java
+++ b/extensions/datastores/accumulo/src/main/java/mil/nga/giat/geowave/datastore/accumulo/AccumuloDataStore.java
@@ -275,6 +275,7 @@ public class AccumuloDataStore implements
 								filter,
 								sanitizedQueryOptions.getScanCallback(),
 								queryOptions.getAggregation(),
+								queryOptions.getFieldIds(),
 								sanitizedQueryOptions.getAuthorizations());
 						results.add(accumuloQuery.query(
 								accumuloOperations,
@@ -308,6 +309,7 @@ public class AccumuloDataStore implements
 									filter,
 									sanitizedQueryOptions.getScanCallback(),
 									queryOptions.getAggregation(),
+									queryOptions.getFieldIds(),
 									sanitizedQueryOptions.getAuthorizations());
 
 							results.add(accumuloQuery.query(
@@ -493,7 +495,7 @@ public class AccumuloDataStore implements
 
 			scanner.fetchColumnFamily(new Text(
 					adapterId.getBytes()));
-			
+
 			scanner.addScanIterator(new IteratorSetting(
 					SharedVisibilitySplittingIterator.ITERATOR_PRIORITY,
 					SharedVisibilitySplittingIterator.ITERATOR_NAME,
@@ -758,6 +760,7 @@ public class AccumuloDataStore implements
 											null,
 											callback,
 											null,
+											queryOptions.getFieldIds(),
 											queryOptions.getAuthorizations()).query(
 											accumuloOperations,
 											adapterStore,

--- a/extensions/datastores/accumulo/src/main/java/mil/nga/giat/geowave/datastore/accumulo/query/AbstractAccumuloRowQuery.java
+++ b/extensions/datastores/accumulo/src/main/java/mil/nga/giat/geowave/datastore/accumulo/query/AbstractAccumuloRowQuery.java
@@ -67,6 +67,15 @@ abstract public class AbstractAccumuloRowQuery<T> extends
 				SharedVisibilitySplittingIterator.ITERATOR_NAME,
 				SharedVisibilitySplittingIterator.class));
 
+		if ((fieldIds != null) && (fieldIds.size() > 0)) {
+			final IteratorSetting iteratorSetting = FieldFilter.getIteratorSetting();
+			FieldFilter.setFieldIds(
+					iteratorSetting,
+					fieldIds,
+					index.getIndexModel().getDimensions());
+			scanner.addScanIterator(iteratorSetting);
+		}
+
 		// we have to at least use a whole row iterator
 		final IteratorSetting iteratorSettings = new IteratorSetting(
 				QueryFilterIterator.WHOLE_ROW_ITERATOR_PRIORITY,

--- a/extensions/datastores/accumulo/src/main/java/mil/nga/giat/geowave/datastore/accumulo/query/AbstractAccumuloRowQuery.java
+++ b/extensions/datastores/accumulo/src/main/java/mil/nga/giat/geowave/datastore/accumulo/query/AbstractAccumuloRowQuery.java
@@ -61,6 +61,12 @@ abstract public class AbstractAccumuloRowQuery<T> extends
 
 	protected void addScanIteratorSettings(
 			final ScannerBase scanner ) {
+
+		scanner.addScanIterator(new IteratorSetting(
+				SharedVisibilitySplittingIterator.ITERATOR_PRIORITY,
+				SharedVisibilitySplittingIterator.ITERATOR_NAME,
+				SharedVisibilitySplittingIterator.class));
+
 		// we have to at least use a whole row iterator
 		final IteratorSetting iteratorSettings = new IteratorSetting(
 				QueryFilterIterator.WHOLE_ROW_ITERATOR_PRIORITY,

--- a/extensions/datastores/accumulo/src/main/java/mil/nga/giat/geowave/datastore/accumulo/query/AccumuloConstraintsQuery.java
+++ b/extensions/datastores/accumulo/src/main/java/mil/nga/giat/geowave/datastore/accumulo/query/AccumuloConstraintsQuery.java
@@ -155,6 +155,12 @@ public class AccumuloConstraintsQuery extends
 	@Override
 	protected void addScanIteratorSettings(
 			final ScannerBase scanner ) {
+
+		scanner.addScanIterator(new IteratorSetting(
+				SharedVisibilitySplittingIterator.ITERATOR_PRIORITY,
+				SharedVisibilitySplittingIterator.ITERATOR_NAME,
+				SharedVisibilitySplittingIterator.class));
+
 		if ((distributableFilters != null) && !distributableFilters.isEmpty() && queryFiltersEnabled) {
 
 			final IteratorSetting iteratorSettings;

--- a/extensions/datastores/accumulo/src/main/java/mil/nga/giat/geowave/datastore/accumulo/query/AccumuloConstraintsQuery.java
+++ b/extensions/datastores/accumulo/src/main/java/mil/nga/giat/geowave/datastore/accumulo/query/AccumuloConstraintsQuery.java
@@ -33,7 +33,7 @@ import com.google.common.collect.Iterators;
 
 /**
  * This class represents basic numeric contraints applied to an Accumulo Query
- * 
+ *
  */
 public class AccumuloConstraintsQuery extends
 		AccumuloFilteredIndexQuery
@@ -52,6 +52,7 @@ public class AccumuloConstraintsQuery extends
 			final DedupeFilter clientDedupeFilter,
 			final ScanCallback<?> scanCallback,
 			final Pair<DataAdapter<?>, Aggregation<?>> aggregation,
+			final List<String> fieldIds,
 			final String[] authorizations ) {
 		this(
 				adapterIds,
@@ -61,54 +62,8 @@ public class AccumuloConstraintsQuery extends
 				clientDedupeFilter,
 				scanCallback,
 				aggregation,
+				fieldIds,
 				authorizations);
-	}
-
-	public AccumuloConstraintsQuery(
-			final PrimaryIndex index,
-			final List<MultiDimensionalNumericData> constraints,
-			final List<QueryFilter> queryFilters ) {
-		this(
-				null,
-				index,
-				constraints,
-				queryFilters,
-				new String[0]);
-	}
-
-	public AccumuloConstraintsQuery(
-			final List<ByteArrayId> adapterIds,
-			final PrimaryIndex index,
-			final List<MultiDimensionalNumericData> constraints,
-			final List<QueryFilter> queryFilters ) {
-		this(
-				adapterIds,
-				index,
-				constraints,
-				queryFilters,
-				(DedupeFilter) null,
-				(ScanCallback<?>) null,
-				null,
-				new String[0]);
-
-	}
-
-	public AccumuloConstraintsQuery(
-			final List<ByteArrayId> adapterIds,
-			final PrimaryIndex index,
-			final List<MultiDimensionalNumericData> constraints,
-			final List<QueryFilter> queryFilters,
-			final String[] authorizations ) {
-		this(
-				adapterIds,
-				index,
-				constraints,
-				queryFilters,
-				(DedupeFilter) null,
-				(ScanCallback<?>) null,
-				null,
-				authorizations);
-
 	}
 
 	public AccumuloConstraintsQuery(
@@ -119,11 +74,13 @@ public class AccumuloConstraintsQuery extends
 			final DedupeFilter clientDedupeFilter,
 			final ScanCallback<?> scanCallback,
 			final Pair<DataAdapter<?>, Aggregation<?>> aggregation,
+			final List<String> fieldIds,
 			final String[] authorizations ) {
 		super(
 				adapterIds,
 				index,
 				scanCallback,
+				fieldIds,
 				authorizations);
 		this.constraints = constraints;
 		this.aggregation = aggregation;
@@ -160,6 +117,15 @@ public class AccumuloConstraintsQuery extends
 				SharedVisibilitySplittingIterator.ITERATOR_PRIORITY,
 				SharedVisibilitySplittingIterator.ITERATOR_NAME,
 				SharedVisibilitySplittingIterator.class));
+
+		if ((fieldIds != null) && (fieldIds.size() > 0)) {
+			final IteratorSetting iteratorSetting = FieldFilter.getIteratorSetting();
+			FieldFilter.setFieldIds(
+					iteratorSetting,
+					fieldIds,
+					index.getIndexModel().getDimensions());
+			scanner.addScanIterator(iteratorSetting);
+		}
 
 		if ((distributableFilters != null) && !distributableFilters.isEmpty() && queryFiltersEnabled) {
 

--- a/extensions/datastores/accumulo/src/main/java/mil/nga/giat/geowave/datastore/accumulo/query/AccumuloFilteredIndexQuery.java
+++ b/extensions/datastores/accumulo/src/main/java/mil/nga/giat/geowave/datastore/accumulo/query/AccumuloFilteredIndexQuery.java
@@ -32,10 +32,12 @@ public abstract class AccumuloFilteredIndexQuery extends
 			final List<ByteArrayId> adapterIds,
 			final PrimaryIndex index,
 			final ScanCallback<?> scanCallback,
+			final List<String> fieldIds,
 			final String... authorizations ) {
 		super(
 				adapterIds,
 				index,
+				fieldIds,
 				authorizations);
 		this.scanCallback = scanCallback;
 	}

--- a/extensions/datastores/accumulo/src/main/java/mil/nga/giat/geowave/datastore/accumulo/query/AccumuloQuery.java
+++ b/extensions/datastores/accumulo/src/main/java/mil/nga/giat/geowave/datastore/accumulo/query/AccumuloQuery.java
@@ -1,5 +1,6 @@
 package mil.nga.giat.geowave.datastore.accumulo.query;
 
+import java.util.Collections;
 import java.util.List;
 
 import mil.nga.giat.geowave.core.index.ByteArrayId;
@@ -29,6 +30,7 @@ abstract public class AccumuloQuery
 	private final static Logger LOGGER = Logger.getLogger(AccumuloQuery.class);
 	protected final List<ByteArrayId> adapterIds;
 	protected final PrimaryIndex index;
+	protected final List<String> fieldIds;
 
 	private final String[] authorizations;
 
@@ -38,15 +40,18 @@ abstract public class AccumuloQuery
 		this(
 				null,
 				index,
+				Collections.<String> emptyList(),
 				authorizations);
 	}
 
 	public AccumuloQuery(
 			final List<ByteArrayId> adapterIds,
 			final PrimaryIndex index,
+			final List<String> fieldIds,
 			final String... authorizations ) {
 		this.adapterIds = adapterIds;
 		this.index = index;
+		this.fieldIds = fieldIds;
 		this.authorizations = authorizations;
 	}
 

--- a/extensions/datastores/accumulo/src/main/java/mil/nga/giat/geowave/datastore/accumulo/query/AccumuloRowIdsQuery.java
+++ b/extensions/datastores/accumulo/src/main/java/mil/nga/giat/geowave/datastore/accumulo/query/AccumuloRowIdsQuery.java
@@ -36,6 +36,7 @@ public class AccumuloRowIdsQuery<T> extends
 				dedupFilter,
 				scanCallback,
 				null,
+				Collections.<String> emptyList(),
 				authorizations);
 		this.rows = rows;
 	}
@@ -54,6 +55,7 @@ public class AccumuloRowIdsQuery<T> extends
 				dedupFilter,
 				scanCallback,
 				null,
+				Collections.<String> emptyList(),
 				authorizations);
 		this.rows = rows;
 	}

--- a/extensions/datastores/accumulo/src/main/java/mil/nga/giat/geowave/datastore/accumulo/query/FieldFilter.java
+++ b/extensions/datastores/accumulo/src/main/java/mil/nga/giat/geowave/datastore/accumulo/query/FieldFilter.java
@@ -1,0 +1,103 @@
+package mil.nga.giat.geowave.datastore.accumulo.query;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+import mil.nga.giat.geowave.core.index.ByteArrayId;
+import mil.nga.giat.geowave.core.index.StringUtils;
+import mil.nga.giat.geowave.core.store.dimension.NumericDimensionField;
+import mil.nga.giat.geowave.core.store.index.CommonIndexValue;
+
+import org.apache.accumulo.core.client.IteratorSetting;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.iterators.Filter;
+import org.apache.accumulo.core.iterators.IteratorEnvironment;
+import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
+
+import com.google.common.base.Splitter;
+
+public class FieldFilter extends
+		Filter
+{
+	// must execute prior to WholeRowIterator/QueryFilterIterator but after
+	// SharedVisibilitySplittingIterator
+	private static final int ITERATOR_PRIORITY = QueryFilterIterator.WHOLE_ROW_ITERATOR_PRIORITY - 1;
+	private static final String ITERATOR_NAME = "FIELD_FILTER_ITERATOR";
+	private static final String FIELD_IDS = "fieldIds";
+	private final Set<ByteArrayId> fieldIds = new HashSet<>();
+
+	@Override
+	public boolean validateOptions(
+			final Map<String, String> options ) {
+		if ((!super.validateOptions(options)) || (options == null) || (!options.containsKey(FIELD_IDS))) {
+			return false;
+		}
+		return true;
+	}
+
+	@Override
+	public void init(
+			final SortedKeyValueIterator<Key, Value> source,
+			final Map<String, String> options,
+			final IteratorEnvironment env )
+			throws IOException {
+		super.init(
+				source,
+				options,
+				env);
+		final Iterable<String> fieldIdsList = Splitter.on(
+				',').split(
+				options.get(FIELD_IDS));
+		for (final String fieldId : fieldIdsList) {
+			fieldIds.add(new ByteArrayId(
+					StringUtils.stringToBinary(fieldId)));
+		}
+	}
+
+	@Override
+	public boolean accept(
+			final Key k,
+			final Value v ) {
+		for (final ByteArrayId fieldId : fieldIds) {
+			if (Arrays.equals(
+					k.getColumnQualifierData().getBackingArray(),
+					fieldId.getBytes())) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	public static IteratorSetting getIteratorSetting() {
+		return new IteratorSetting(
+				FieldFilter.ITERATOR_PRIORITY,
+				FieldFilter.ITERATOR_NAME,
+				FieldFilter.class);
+	}
+
+	public static void setFieldIds(
+			final IteratorSetting setting,
+			final List<String> fieldIds,
+			final NumericDimensionField<? extends CommonIndexValue>[] numericDimensions ) {
+		final Set<String> desiredSubset = new TreeSet<>();
+		// add fieldIds
+		desiredSubset.addAll(fieldIds);
+		// dimension fields must also be included
+		for (final NumericDimensionField<? extends CommonIndexValue> dimension : numericDimensions) {
+			desiredSubset.add(StringUtils.stringFromBinary(dimension.getFieldId().getBytes()));
+		}
+		final String fieldIdsString = org.apache.commons.lang3.StringUtils.join(
+				desiredSubset,
+				',');
+		setting.addOption(
+				FieldFilter.FIELD_IDS,
+				fieldIdsString);
+	}
+
+}

--- a/extensions/datastores/accumulo/src/main/java/mil/nga/giat/geowave/datastore/accumulo/query/InputFormatAccumuloRangeQuery.java
+++ b/extensions/datastores/accumulo/src/main/java/mil/nga/giat/geowave/datastore/accumulo/query/InputFormatAccumuloRangeQuery.java
@@ -5,13 +5,6 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
-import org.apache.accumulo.core.client.Scanner;
-import org.apache.accumulo.core.client.ScannerBase;
-import org.apache.accumulo.core.client.TableNotFoundException;
-import org.apache.accumulo.core.data.Range;
-import org.apache.hadoop.io.Text;
-import org.apache.log4j.Logger;
-
 import mil.nga.giat.geowave.core.index.ByteArrayId;
 import mil.nga.giat.geowave.core.store.adapter.AdapterStore;
 import mil.nga.giat.geowave.core.store.filter.DedupeFilter;
@@ -21,6 +14,13 @@ import mil.nga.giat.geowave.core.store.index.PrimaryIndex;
 import mil.nga.giat.geowave.core.store.query.QueryOptions;
 import mil.nga.giat.geowave.datastore.accumulo.AccumuloOperations;
 import mil.nga.giat.geowave.datastore.accumulo.util.InputFormatIteratorWrapper;
+
+import org.apache.accumulo.core.client.Scanner;
+import org.apache.accumulo.core.client.ScannerBase;
+import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.data.Range;
+import org.apache.hadoop.io.Text;
+import org.apache.log4j.Logger;
 
 /**
  * * Represents a query operation for a range of Accumulo row IDs. This class is
@@ -69,6 +69,7 @@ public class InputFormatAccumuloRangeQuery extends
 				(DedupeFilter) null,
 				queryOptions.getScanCallback(),
 				null,
+				Collections.<String> emptyList(),
 				queryOptions.getAuthorizations());
 
 		this.accumuloRange = accumuloRange;

--- a/extensions/datastores/accumulo/src/main/java/mil/nga/giat/geowave/datastore/accumulo/query/QueryFilterIterator.java
+++ b/extensions/datastores/accumulo/src/main/java/mil/nga/giat/geowave/datastore/accumulo/query/QueryFilterIterator.java
@@ -9,7 +9,6 @@ import java.util.Map;
 import mil.nga.giat.geowave.core.index.ByteArrayId;
 import mil.nga.giat.geowave.core.index.ByteArrayUtils;
 import mil.nga.giat.geowave.core.index.PersistenceUtils;
-import mil.nga.giat.geowave.core.store.DataStoreEntryInfo.FieldInfo;
 import mil.nga.giat.geowave.core.store.data.CommonIndexedPersistenceEncoding;
 import mil.nga.giat.geowave.core.store.data.PersistentDataset;
 import mil.nga.giat.geowave.core.store.data.PersistentValue;
@@ -18,7 +17,6 @@ import mil.nga.giat.geowave.core.store.filter.DistributableQueryFilter;
 import mil.nga.giat.geowave.core.store.index.CommonIndexModel;
 import mil.nga.giat.geowave.core.store.index.CommonIndexValue;
 import mil.nga.giat.geowave.datastore.accumulo.AccumuloRowId;
-import mil.nga.giat.geowave.datastore.accumulo.util.AccumuloUtils;
 
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
@@ -107,46 +105,20 @@ public class QueryFilterIterator extends
 				final Key key = keys.get(i);
 				final ByteArrayId colQual = new ByteArrayId(
 						key.getColumnQualifierData().getBackingArray());
-				if (colQual.equals(AccumuloUtils.COMPOSITE_CQ)) {
-					final byte[] valueBytes = values.get(
-							i).get();
-					final List<FieldInfo<Object>> fieldInfos = AccumuloUtils.decomposeFlattenedFields(
-							model,
-							valueBytes,
-							key.getColumnVisibilityData().getBackingArray());
-					for (final FieldInfo<Object> fieldInfo : fieldInfos) {
-						final ByteArrayId fieldId = fieldInfo.getDataValue().getId();
-						final FieldReader<? extends CommonIndexValue> reader = model.getReader(fieldId);
-						if (reader != null) {
-							final CommonIndexValue fieldValue = reader.readField(fieldInfo.getWrittenValue());
-							fieldValue.setVisibility(fieldInfo.getVisibility());
-							commonData.addValue(new PersistentValue<CommonIndexValue>(
-									fieldId,
-									fieldValue));
-						}
-						else {
-							unknownData.addValue(new PersistentValue<byte[]>(
-									fieldId,
-									fieldInfo.getWrittenValue()));
-						}
-					}
+				final FieldReader<? extends CommonIndexValue> reader = model.getReader(colQual);
+				if (reader != null) {
+					final CommonIndexValue fieldValue = reader.readField(values.get(
+							i).get());
+					fieldValue.setVisibility(key.getColumnVisibilityData().getBackingArray());
+					commonData.addValue(new PersistentValue<CommonIndexValue>(
+							colQual,
+							fieldValue));
 				}
 				else {
-					final FieldReader<? extends CommonIndexValue> reader = model.getReader(colQual);
-					if (reader != null) {
-						final CommonIndexValue fieldValue = reader.readField(values.get(
-								i).get());
-						fieldValue.setVisibility(key.getColumnVisibilityData().getBackingArray());
-						commonData.addValue(new PersistentValue<CommonIndexValue>(
-								colQual,
-								fieldValue));
-					}
-					else {
-						unknownData.addValue(new PersistentValue<byte[]>(
-								colQual,
-								values.get(
-										i).get()));
-					}
+					unknownData.addValue(new PersistentValue<byte[]>(
+							colQual,
+							values.get(
+									i).get()));
 				}
 			}
 			final CommonIndexedPersistenceEncoding encoding = new CommonIndexedPersistenceEncoding(

--- a/extensions/datastores/accumulo/src/main/java/mil/nga/giat/geowave/datastore/accumulo/query/SharedVisibilitySplittingIterator.java
+++ b/extensions/datastores/accumulo/src/main/java/mil/nga/giat/geowave/datastore/accumulo/query/SharedVisibilitySplittingIterator.java
@@ -1,0 +1,102 @@
+package mil.nga.giat.geowave.datastore.accumulo.query;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import mil.nga.giat.geowave.datastore.accumulo.util.AccumuloUtils;
+
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.PartialKey;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
+import org.apache.accumulo.core.iterators.user.TransformingIterator;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.hadoop.io.Text;
+
+public class SharedVisibilitySplittingIterator extends
+		TransformingIterator
+{
+	// must execute prior to WholeRowIterator/QueryFilterIterator
+	public static final int ITERATOR_PRIORITY = QueryFilterIterator.WHOLE_ROW_ITERATOR_PRIORITY - 1;
+	public static final String ITERATOR_NAME = "SHRD_VIZ_SPLT_ITERATOR";
+
+	@Override
+	protected PartialKey getKeyPrefix() {
+		// this iterator may modify CQ, but will not modify CF
+		return PartialKey.ROW_COLFAM;
+	}
+
+	@Override
+	protected void transformRange(
+			final SortedKeyValueIterator<Key, Value> input,
+			final KVBuffer output )
+			throws IOException {
+
+		while (input.hasTop()) {
+
+			final Key currKey = input.getTopKey();
+			final Value currVal = input.getTopValue();
+
+			// check to see if the current value is a composite field containing
+			// multiple attributes with shared visibility
+			if (Arrays.equals(
+					currKey.getColumnQualifierData().getBackingArray(), // fieldId
+					AccumuloUtils.COMPOSITE_CQ.getBytes())) {
+				// decompose and add transformed <K,V> pairs to output buffer
+				for (final Pair<byte[], byte[]> pair : decomposeFlattenedValue(currVal)) {
+					final Key newKey = replaceColumnQualifier(
+							currKey,
+							new Text(
+									pair.getLeft()));
+					final Value newVal = new Value(
+							pair.getRight());
+					output.append(
+							newKey,
+							newVal);
+				}
+			}
+
+			// simply pass along single (non-composite) value as is
+			else {
+				output.append(
+						currKey,
+						currVal);
+			}
+
+			input.next();
+		}
+	}
+
+	private List<Pair<byte[], byte[]>> decomposeFlattenedValue(
+			final Value value ) {
+
+		final List<Pair<byte[], byte[]>> retVal = new ArrayList<>();
+		final ByteBuffer input = ByteBuffer.wrap(value.get());
+
+		// read the number of attributes combined into this single value
+		final int numFields = input.getInt();
+
+		// parse out individual <fieldId, value> pairs
+		for (int x = 0; x < numFields; x++) {
+
+			// fieldId
+			final int fieldIdLength = input.getInt();
+			final byte[] fieldIdBytes = new byte[fieldIdLength];
+			input.get(fieldIdBytes);
+
+			// attribute value
+			final int fieldLength = input.getInt();
+			final byte[] fieldValueBytes = new byte[fieldLength];
+			input.get(fieldValueBytes);
+
+			retVal.add(Pair.of(
+					fieldIdBytes,
+					fieldValueBytes));
+		}
+
+		return retVal;
+	}
+}

--- a/extensions/datastores/accumulo/src/main/java/mil/nga/giat/geowave/datastore/accumulo/query/SharedVisibilitySplittingIterator.java
+++ b/extensions/datastores/accumulo/src/main/java/mil/nga/giat/geowave/datastore/accumulo/query/SharedVisibilitySplittingIterator.java
@@ -20,7 +20,7 @@ public class SharedVisibilitySplittingIterator extends
 		TransformingIterator
 {
 	// must execute prior to WholeRowIterator/QueryFilterIterator
-	public static final int ITERATOR_PRIORITY = QueryFilterIterator.WHOLE_ROW_ITERATOR_PRIORITY - 1;
+	public static final int ITERATOR_PRIORITY = QueryFilterIterator.WHOLE_ROW_ITERATOR_PRIORITY - 2;
 	public static final String ITERATOR_NAME = "SHRD_VIZ_SPLT_ITERATOR";
 
 	@Override

--- a/extensions/datastores/accumulo/src/main/java/mil/nga/giat/geowave/datastore/accumulo/util/AccumuloUtils.java
+++ b/extensions/datastores/accumulo/src/main/java/mil/nga/giat/geowave/datastore/accumulo/util/AccumuloUtils.java
@@ -1042,6 +1042,7 @@ public class AccumuloUtils
 					null,
 					null,
 					null,
+					null,
 					new String[0]);
 			final CloseableIterator<?> iterator = accumuloQuery.query(
 					operations,
@@ -1085,6 +1086,7 @@ public class AccumuloUtils
 			final AccumuloConstraintsQuery accumuloQuery = new AccumuloConstraintsQuery(
 					null,
 					index,
+					null,
 					null,
 					null,
 					null,

--- a/extensions/datastores/accumulo/src/main/java/mil/nga/giat/geowave/datastore/accumulo/util/AccumuloUtils.java
+++ b/extensions/datastores/accumulo/src/main/java/mil/nga/giat/geowave/datastore/accumulo/util/AccumuloUtils.java
@@ -16,24 +16,6 @@ import java.util.SortedMap;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
-import org.apache.accumulo.core.client.AccumuloException;
-import org.apache.accumulo.core.client.AccumuloSecurityException;
-import org.apache.accumulo.core.client.BatchScanner;
-import org.apache.accumulo.core.client.Connector;
-import org.apache.accumulo.core.client.IteratorSetting;
-import org.apache.accumulo.core.client.ScannerBase;
-import org.apache.accumulo.core.client.TableNotFoundException;
-import org.apache.accumulo.core.data.Key;
-import org.apache.accumulo.core.data.Mutation;
-import org.apache.accumulo.core.data.Range;
-import org.apache.accumulo.core.data.Value;
-import org.apache.accumulo.core.iterators.IteratorUtil.IteratorScope;
-import org.apache.accumulo.core.iterators.user.WholeRowIterator;
-import org.apache.accumulo.core.security.ColumnVisibility;
-import org.apache.commons.lang3.tuple.Pair;
-import org.apache.hadoop.io.Text;
-import org.apache.log4j.Logger;
-
 import mil.nga.giat.geowave.core.index.ByteArrayId;
 import mil.nga.giat.geowave.core.index.ByteArrayRange;
 import mil.nga.giat.geowave.core.index.StringUtils;
@@ -77,6 +59,24 @@ import mil.nga.giat.geowave.datastore.accumulo.metadata.AbstractAccumuloPersiste
 import mil.nga.giat.geowave.datastore.accumulo.metadata.AccumuloAdapterStore;
 import mil.nga.giat.geowave.datastore.accumulo.metadata.AccumuloIndexStore;
 import mil.nga.giat.geowave.datastore.accumulo.query.AccumuloConstraintsQuery;
+
+import org.apache.accumulo.core.client.AccumuloException;
+import org.apache.accumulo.core.client.AccumuloSecurityException;
+import org.apache.accumulo.core.client.BatchScanner;
+import org.apache.accumulo.core.client.Connector;
+import org.apache.accumulo.core.client.IteratorSetting;
+import org.apache.accumulo.core.client.ScannerBase;
+import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Mutation;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.iterators.IteratorUtil.IteratorScope;
+import org.apache.accumulo.core.iterators.user.WholeRowIterator;
+import org.apache.accumulo.core.security.ColumnVisibility;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.hadoop.io.Text;
+import org.apache.log4j.Logger;
 
 /**
  * A set of convenience methods for common operations on Accumulo within
@@ -305,84 +305,42 @@ public class AccumuloUtils
 			final byte byteValue[] = entry.getValue().get();
 			final ByteArrayId fieldId = new ByteArrayId(
 					entry.getKey().getColumnQualifierData().getBackingArray());
-			if ((adapter instanceof AbstractDataAdapter<?>) && (fieldId.equals(COMPOSITE_CQ))) {
-				final List<FieldInfo<Object>> fieldInfos = decomposeFlattenedFields(
-						indexModel,
+
+			final FieldReader<? extends CommonIndexValue> indexFieldReader = indexModel.getReader(fieldId);
+			if (indexFieldReader != null) {
+				final CommonIndexValue indexValue = indexFieldReader.readField(byteValue);
+				indexValue.setVisibility(entry.getKey().getColumnVisibilityData().getBackingArray());
+				final PersistentValue<CommonIndexValue> val = new PersistentValue<CommonIndexValue>(
+						fieldId,
+						indexValue);
+				indexData.addValue(val);
+				fieldInfoList.add(DataStoreUtils.getFieldInfo(
+						val,
 						byteValue,
-						entry.getKey().getColumnVisibilityData().getBackingArray());
-				for (final FieldInfo<Object> fieldInfo : fieldInfos) {
-					final FieldReader<? extends CommonIndexValue> indexFieldReader = indexModel.getReader(fieldInfo.getDataValue().getId());
-					if (indexFieldReader != null) {
-						final CommonIndexValue indexValue = indexFieldReader.readField(fieldInfo.getWrittenValue());
-						indexValue.setVisibility(entry.getKey().getColumnVisibilityData().getBackingArray());
-						final PersistentValue<CommonIndexValue> val = new PersistentValue<CommonIndexValue>(
-								fieldInfo.getDataValue().getId(),
-								indexValue);
-						indexData.addValue(val);
-						fieldInfoList.add(DataStoreUtils.getFieldInfo(
-								val,
-								fieldInfo.getWrittenValue(),
-								entry.getKey().getColumnVisibilityData().getBackingArray()));
-					}
-					else {
-						final FieldReader<?> extFieldReader = adapter.getReader(fieldInfo.getDataValue().getId());
-						if (extFieldReader != null) {
-							final Object value = extFieldReader.readField(fieldInfo.getWrittenValue());
-							final PersistentValue<Object> val = new PersistentValue<Object>(
-									fieldInfo.getDataValue().getId(),
-									value);
-							extendedData.addValue(val);
-							fieldInfoList.add(DataStoreUtils.getFieldInfo(
-									val,
-									fieldInfo.getWrittenValue(),
-									entry.getKey().getColumnVisibilityData().getBackingArray()));
-						}
-						else {
-							LOGGER.error("field reader not found for data entry, the value may be ignored");
-							unknownData.addValue(new PersistentValue<byte[]>(
-									fieldInfo.getDataValue().getId(),
-									fieldInfo.getWrittenValue()));
-						}
-					}
-				}
+						indexValue.getVisibility()));
 			}
 			else {
-				final FieldReader<? extends CommonIndexValue> indexFieldReader = indexModel.getReader(fieldId);
-				if (indexFieldReader != null) {
-					final CommonIndexValue indexValue = indexFieldReader.readField(byteValue);
-					indexValue.setVisibility(entry.getKey().getColumnVisibilityData().getBackingArray());
-					final PersistentValue<CommonIndexValue> val = new PersistentValue<CommonIndexValue>(
+				// next check if this field is part of the adapter's
+				// extended data model
+				final FieldReader<?> extFieldReader = adapter.getReader(fieldId);
+				if (extFieldReader == null) {
+					// if it still isn't resolved, log an error, and
+					// continue
+					LOGGER.error("field reader not found for data entry, the value may be ignored");
+					unknownData.addValue(new PersistentValue<byte[]>(
 							fieldId,
-							indexValue);
-					indexData.addValue(val);
-					fieldInfoList.add(DataStoreUtils.getFieldInfo(
-							val,
-							byteValue,
-							indexValue.getVisibility()));
+							byteValue));
+					continue;
 				}
-				else {
-					// next check if this field is part of the adapter's
-					// extended data model
-					final FieldReader<?> extFieldReader = adapter.getReader(fieldId);
-					if (extFieldReader == null) {
-						// if it still isn't resolved, log an error, and
-						// continue
-						LOGGER.error("field reader not found for data entry, the value may be ignored");
-						unknownData.addValue(new PersistentValue<byte[]>(
-								fieldId,
-								byteValue));
-						continue;
-					}
-					final Object value = extFieldReader.readField(byteValue);
-					final PersistentValue<Object> val = new PersistentValue<Object>(
-							fieldId,
-							value);
-					extendedData.addValue(val);
-					fieldInfoList.add(DataStoreUtils.getFieldInfo(
-							val,
-							byteValue,
-							entry.getKey().getColumnVisibility().getBytes()));
-				}
+				final Object value = extFieldReader.readField(byteValue);
+				final PersistentValue<Object> val = new PersistentValue<Object>(
+						fieldId,
+						value);
+				extendedData.addValue(val);
+				fieldInfoList.add(DataStoreUtils.getFieldInfo(
+						val,
+						byteValue,
+						entry.getKey().getColumnVisibility().getBytes()));
 			}
 		}
 		final IndexedAdapterPersistenceEncoding encodedRow = new IndexedAdapterPersistenceEncoding(
@@ -627,51 +585,6 @@ public class AccumuloUtils
 			retVal.add(composite);
 		}
 		return retVal;
-	}
-
-	/**
-	 * Takes a byte array representing a serialized composite group of
-	 * FieldInfos sharing a common visibility and returns a List of the
-	 * individual FieldInfos
-	 * 
-	 * @param model
-	 * @param flattenedValue
-	 *            the serialized composite FieldInfo
-	 * @param commonVisibility
-	 *            the shared visibility
-	 * @return
-	 */
-	public static <T> List<FieldInfo<Object>> decomposeFlattenedFields(
-			final CommonIndexModel model,
-			final byte[] flattenedValue,
-			final byte[] commonVisibility ) {
-		final List<FieldInfo<Object>> fieldInfoList = new ArrayList<>();
-		final ByteBuffer input = ByteBuffer.wrap(flattenedValue);
-		final int numFields = input.getInt();
-		for (int x = 0; x < numFields; x++) {
-			final int fieldIdLength = input.getInt();
-			final byte[] fieldIdBytes = new byte[fieldIdLength];
-			input.get(fieldIdBytes);
-			final int fieldLength = input.getInt();
-			final byte[] fieldValueBytes = new byte[fieldLength];
-			input.get(fieldValueBytes);
-			final ByteArrayId fieldId = new ByteArrayId(
-					fieldIdBytes);
-			final FieldReader<? extends CommonIndexValue> fieldReader = model.getReader(fieldId);
-			Object fieldValue = null;
-			if (fieldReader != null) {
-				fieldValue = fieldReader.readField(fieldValueBytes);
-			}
-			final PersistentValue<Object> persistentValue = new PersistentValue<Object>(
-					fieldId,
-					fieldValue);
-			final FieldInfo<Object> fieldInfo = DataStoreUtils.getFieldInfo(
-					persistentValue,
-					fieldValueBytes,
-					commonVisibility);
-			fieldInfoList.add(fieldInfo);
-		}
-		return fieldInfoList;
 	}
 
 	/**


### PR DESCRIPTION
Fix for #615

SharedVisibilitySplittingIterator decomposes composite fieldIds on the tablet server, which replaces the old approach of doing this twice (once client side in AccumuloUtils and also in QueryFilterIterator)

FieldFilter filters only those fieldIds that were specified in QueryOptions

AttributesSubsetQueryIT tests both server side and client side filtering functionality

We also support subsetting through GeoTools Query via propertyNames.  GeoToolsAttributesSubsetTest verifies this functionality