### PR TITLE
GEOWAVE-546 - Throw exception if index doesn't exist

### DIFF
--- a/core/ingest/src/main/java/mil/nga/giat/geowave/core/ingest/operations/KafkaToGeowaveCommand.java
+++ b/core/ingest/src/main/java/mil/nga/giat/geowave/core/ingest/operations/KafkaToGeowaveCommand.java
@@ -100,7 +100,10 @@ public class KafkaToGeowaveCommand implements
 		if (inputIndexOptions == null) {
 			IndexLoader indexLoader = new IndexLoader(
 					indexList);
-			indexLoader.loadFromConfig(configFile);
+			if (!indexLoader.loadFromConfig(configFile)) {
+				throw new ParameterException(
+						"Cannot find index(s) by name: " + indexList);
+			}
 			inputIndexOptions = indexLoader.getLoadedIndexes();
 		}
 

--- a/core/ingest/src/main/java/mil/nga/giat/geowave/core/ingest/operations/LocalToGeowaveCommand.java
+++ b/core/ingest/src/main/java/mil/nga/giat/geowave/core/ingest/operations/LocalToGeowaveCommand.java
@@ -100,7 +100,10 @@ public class LocalToGeowaveCommand implements
 		if (inputIndexOptions == null) {
 			IndexLoader indexLoader = new IndexLoader(
 					indexList);
-			indexLoader.loadFromConfig(configFile);
+			if (!indexLoader.loadFromConfig(configFile)) {
+				throw new ParameterException(
+						"Cannot find index(s) by name: " + indexList);
+			}
 			inputIndexOptions = indexLoader.getLoadedIndexes();
 		}
 

--- a/core/ingest/src/main/java/mil/nga/giat/geowave/core/ingest/operations/LocalToMapReduceToGeowaveCommand.java
+++ b/core/ingest/src/main/java/mil/nga/giat/geowave/core/ingest/operations/LocalToMapReduceToGeowaveCommand.java
@@ -112,7 +112,10 @@ public class LocalToMapReduceToGeowaveCommand implements
 		if (inputIndexOptions == null) {
 			IndexLoader indexLoader = new IndexLoader(
 					indexList);
-			indexLoader.loadFromConfig(configFile);
+			if (!indexLoader.loadFromConfig(configFile)) {
+				throw new ParameterException(
+						"Cannot find index(s) by name: " + indexList);
+			}
 			inputIndexOptions = indexLoader.getLoadedIndexes();
 		}
 

--- a/core/ingest/src/main/java/mil/nga/giat/geowave/core/ingest/operations/MapReduceToGeowaveCommand.java
+++ b/core/ingest/src/main/java/mil/nga/giat/geowave/core/ingest/operations/MapReduceToGeowaveCommand.java
@@ -112,7 +112,10 @@ public class MapReduceToGeowaveCommand implements
 		if (inputIndexOptions == null) {
 			IndexLoader indexLoader = new IndexLoader(
 					indexList);
-			indexLoader.loadFromConfig(configFile);
+			if (!indexLoader.loadFromConfig(configFile)) {
+				throw new ParameterException(
+						"Cannot find index(s) by name: " + indexList);
+			}
 			inputIndexOptions = indexLoader.getLoadedIndexes();
 		}
 


### PR DESCRIPTION
Apparently I missed this.  If the index doesn't exist when they specify it on the command line, it will just ignore it and pass 0 indexes