### PR TITLE
GEOWAVE-727 - Fix issue introduced with this PR

### DIFF
--- a/core/store/src/main/java/mil/nga/giat/geowave/core/store/GeoWaveStoreFinder.java
+++ b/core/store/src/main/java/mil/nga/giat/geowave/core/store/GeoWaveStoreFinder.java
@@ -122,9 +122,10 @@ public class GeoWaveStoreFinder
 
 	public static StoreFactoryFamilySpi findStoreFamily(
 			final Map<String, String> configOptions ) {
+		Map<String, StoreFactoryFamilySpi> factories = getRegisteredStoreFactoryFamilies();
 		final Object storeHint = configOptions.get(STORE_HINT_KEY);
 		if (storeHint != null) {
-			final StoreFactoryFamilySpi factory = registeredStoreFactoryFamilies.get(storeHint.toString());
+			final StoreFactoryFamilySpi factory = factories.get(storeHint.toString());
 			if (factory != null) {
 				final List<String> missingOptions = getMissingRequiredOptions(
 						factory,
@@ -150,7 +151,7 @@ public class GeoWaveStoreFinder
 		// the arguments; if there are multiple factories that match and have
 		// the same number of options, arbitrarily the last one will be chosen
 		// and a warning message will be logged
-		for (final Entry<String, StoreFactoryFamilySpi> entry : registeredStoreFactoryFamilies.entrySet()) {
+		for (final Entry<String, StoreFactoryFamilySpi> entry : factories.entrySet()) {
 			final StoreFactoryFamilySpi factory = entry.getValue();
 			final List<String> missingOptions = getMissingRequiredOptions(
 					factory,


### PR DESCRIPTION
The registered families was not being instantiated unless manually done.  In DataStorePluginOptions, this is done for us, but it wouldn't be done under manual usage of GeoWaveStoreFinder.