### PR TITLE
GEOWAVE-546 & GEOWAVE-696 Fixes / Updates

### DIFF
--- a/core/ingest/src/main/java/mil/nga/giat/geowave/core/ingest/kafka/KafkaCommandLineOptions.java
+++ b/core/ingest/src/main/java/mil/nga/giat/geowave/core/ingest/kafka/KafkaCommandLineOptions.java
@@ -43,8 +43,8 @@ public class KafkaCommandLineOptions
 					throw new ParameterException(
 							"Unable to read properties file");
 				}
-				applyOverrides(properties);
 			}
+			applyOverrides(properties);
 			kafkaProperties = properties;
 		}
 	}

--- a/core/ingest/src/main/java/mil/nga/giat/geowave/core/ingest/operations/KafkaToGeowaveCommand.java
+++ b/core/ingest/src/main/java/mil/nga/giat/geowave/core/ingest/operations/KafkaToGeowaveCommand.java
@@ -52,6 +52,8 @@ public class KafkaToGeowaveCommand implements
 
 	private List<IndexPluginOptions> inputIndexOptions = null;
 
+	protected IngestFromKafkaDriver driver = null;
+
 	@Override
 	public boolean prepare(
 			OperationParams params ) {
@@ -111,7 +113,7 @@ public class KafkaToGeowaveCommand implements
 		Map<String, AvroFormatPlugin<?, ?>> ingestPlugins = pluginFormats.createAvroPlugins();
 
 		// Driver
-		IngestFromKafkaDriver driver = new IngestFromKafkaDriver(
+		driver = new IngestFromKafkaDriver(
 				inputStoreOptions,
 				inputIndexOptions,
 				ingestPlugins,
@@ -123,6 +125,10 @@ public class KafkaToGeowaveCommand implements
 			throw new RuntimeException(
 					"Ingest failed to execute");
 		}
+	}
+
+	public IngestFromKafkaDriver getDriver() {
+		return driver;
 	}
 
 	public List<String> getParameters() {

--- a/core/store/src/main/java/mil/nga/giat/geowave/core/store/IngestCallbackList.java
+++ b/core/store/src/main/java/mil/nga/giat/geowave/core/store/IngestCallbackList.java
@@ -37,7 +37,8 @@ public class IngestCallbackList<T> implements
 	}
 
 	@Override
-	public void flush() throws IOException {
+	public void flush()
+			throws IOException {
 		for (final IngestCallback<T> callback : callbacks) {
 			if (callback instanceof Flushable) ((Flushable) callback).flush();
 		}

--- a/core/store/src/main/java/mil/nga/giat/geowave/core/store/IngestCallbackList.java
+++ b/core/store/src/main/java/mil/nga/giat/geowave/core/store/IngestCallbackList.java
@@ -1,11 +1,13 @@
 package mil.nga.giat.geowave.core.store;
 
 import java.io.Closeable;
+import java.io.Flushable;
 import java.io.IOException;
 import java.util.List;
 
 public class IngestCallbackList<T> implements
 		IngestCallback<T>,
+		Flushable,
 		Closeable
 {
 	private final List<IngestCallback<T>> callbacks;
@@ -31,6 +33,13 @@ public class IngestCallbackList<T> implements
 			throws IOException {
 		for (final IngestCallback<T> callback : callbacks) {
 			if (callback instanceof Closeable) ((Closeable) callback).close();
+		}
+	}
+
+	@Override
+	public void flush() throws IOException {
+		for (final IngestCallback<T> callback : callbacks) {
+			if (callback instanceof Flushable) ((Flushable) callback).flush();
 		}
 	}
 

--- a/test/src/main/java/mil/nga/giat/geowave/test/GeoWaveITRunner.java
+++ b/test/src/main/java/mil/nga/giat/geowave/test/GeoWaveITRunner.java
@@ -5,10 +5,12 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.text.MessageFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.ListIterator;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -423,8 +425,11 @@ public class GeoWaveITRunner extends
 			throws Exception {
 		synchronized (MUTEX) {
 			if (!DEFER_CLEANUP.get()) {
-				for (final TestEnvironment e : testEnvs) {
-					e.tearDown();
+				// Tearodwn in reverse
+				List<TestEnvironment> envs = Arrays.asList(testEnvs);
+				ListIterator<TestEnvironment> it = envs.listIterator();
+				while (it.hasPrevious()) {
+					it.previous().tearDown();
 				}
 			}
 		}

--- a/test/src/main/java/mil/nga/giat/geowave/test/kafka/KafkaTestUtils.java
+++ b/test/src/main/java/mil/nga/giat/geowave/test/kafka/KafkaTestUtils.java
@@ -87,12 +87,10 @@ public class KafkaTestUtils
 		kafkaToGeowave.setPluginFormats(ingestFormatOptions);
 		kafkaToGeowave.setInputIndexOptions(Arrays.asList(indexOption));
 		kafkaToGeowave.setInputStoreOptions(options);
-		kafkaToGeowave.getKafkaOptions().setBatchSize(
-				1);
 		kafkaToGeowave.getKafkaOptions().setConsumerTimeoutMs(
 				"5000");
 		kafkaToGeowave.getKafkaOptions().setReconnectOnTimeout(
-				true);
+				false);
 		kafkaToGeowave.getKafkaOptions().setGroupId(
 				"testGroup");
 		kafkaToGeowave.getKafkaOptions().setAutoOffsetReset(
@@ -106,6 +104,19 @@ public class KafkaTestUtils
 				null);
 
 		kafkaToGeowave.execute(new ManualOperationParams());
+
+		// Wait for ingest to complete. This works because we have set
+		// Kafka Consumer to Timeout and set the timeout at 5000 ms, and
+		// then not to re-connect. Since this is a unit test that should
+		// be fine. Basically read all data that's in the stream and
+		// finish.
+		try {
+			kafkaToGeowave.getDriver().waitFutures();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(
+					e);
+		}
 	}
 
 	public static KafkaConfig getKafkaBrokerConfig() {

--- a/test/src/test/java/mil/nga/giat/geowave/test/GeoWaveITSuite.java
+++ b/test/src/test/java/mil/nga/giat/geowave/test/GeoWaveITSuite.java
@@ -6,6 +6,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite.SuiteClasses;
 
 import mil.nga.giat.geowave.test.config.ConfigCacheIT;
+import mil.nga.giat.geowave.test.kafka.BasicKafkaIT;
 import mil.nga.giat.geowave.test.mapreduce.BasicMapReduceIT;
 import mil.nga.giat.geowave.test.mapreduce.BulkIngestInputGenerationIT;
 import mil.nga.giat.geowave.test.mapreduce.DBScanIT;
@@ -23,6 +24,7 @@ import mil.nga.giat.geowave.test.service.GeoWaveServicesIT;
 @RunWith(GeoWaveITSuiteRunner.class)
 @SuiteClasses({
 	GeoWaveBasicIT.class,
+	BasicKafkaIT.class,
 	BasicMapReduceIT.class,
 	GeoWaveRasterIT.class,
 	BulkIngestInputGenerationIT.class,

--- a/test/src/test/java/mil/nga/giat/geowave/test/kafka/BasicKafkaIT.java
+++ b/test/src/test/java/mil/nga/giat/geowave/test/kafka/BasicKafkaIT.java
@@ -83,8 +83,7 @@ public class BasicKafkaIT
 				dataStorePluginOptions,
 				false,
 				OSM_GPX_INPUT_DIR);
-		// wait a sufficient time for consumers to ingest all of the data
-		Thread.sleep(60000);
+
 		final DataStatisticsStore statsStore = dataStorePluginOptions.createDataStatisticsStore();
 		final AdapterStore adapterStore = dataStorePluginOptions.createAdapterStore();
 		int adapterCount = 0;


### PR DESCRIPTION
For GEOWAVE #546: If a kafka properties file isn't selected, then it won't apply command line options to the kafka config properties.  Changed it so that it will do it whether the config file is specified or not.

For GEOWAVE #696: Fixed IndexCallbackList to implement Flushable, which will then allow the IndexWriter.flush() method to flush properly.  Also, modified IT tearDown code to work in reverse order.  For Kafka IT, it was tearing down Accumulo (with zookeeper) before tearing down kafka, and the kafka client was in an infinite loop trying to re-connect to zookeeper at the end of the IT.

Also, modified the BasicKafkaIT to not wait randomly 60 seconds, but instead to wait until all the data has been ingested, and the consumer times out before continuing the integration test.  This will allow different systems with different performance specs to run the IT reliably.  Added it back to GeoWaveITSuite.