### PR TITLE
GEOWAVE-737: update examples to use new 0.9.1 commandline syntax

### DIFF
--- a/core/ingest/src/main/java/mil/nga/giat/geowave/core/ingest/operations/IngestOperationProvider.java
+++ b/core/ingest/src/main/java/mil/nga/giat/geowave/core/ingest/operations/IngestOperationProvider.java
@@ -9,7 +9,7 @@ public class IngestOperationProvider implements
 	private static final Class<?>[] OPERATIONS = new Class<?>[] {
 		IngestSection.class,
 		KafkaToGeowaveCommand.class,
-		ListFormatCommand.class,
+		ListPluginsCommand.class,
 		LocalToGeowaveCommand.class,
 		LocalToHdfsCommand.class,
 		LocalToKafkaCommand.class,

--- a/core/ingest/src/main/java/mil/nga/giat/geowave/core/ingest/operations/ListPluginsCommand.java
+++ b/core/ingest/src/main/java/mil/nga/giat/geowave/core/ingest/operations/ListPluginsCommand.java
@@ -19,9 +19,9 @@ import mil.nga.giat.geowave.core.store.StoreFactoryFamilySpi;
 import mil.nga.giat.geowave.core.store.spi.DimensionalityTypeProviderSpi;
 import mil.nga.giat.geowave.core.store.spi.DimensionalityTypeRegistry;
 
-@GeowaveOperation(name = "listformat", parentOperation = IngestSection.class)
-@Parameters(commandDescription = "List supported ingest formats")
-public class ListFormatCommand extends
+@GeowaveOperation(name = "listplugins", parentOperation = IngestSection.class)
+@Parameters(commandDescription = "List supported data store types, index types, and ingest formats")
+public class ListPluginsCommand extends
 		DefaultOperation implements
 		Command
 {

--- a/docs/content/050-ingest-example.adoc
+++ b/docs/content/050-ingest-example.adoc
@@ -21,17 +21,25 @@ $ cd ingest
 $ unzip ne_50m_admin_0_countries.zip
 $ rm ne_50m_admin_0_countries.zip
 $ cd ..
-$ geowave -localingest \
-      -b ./ingest \
-      -gwNamespace geowave.50m_admin_0_countries \ <1>
-      -f geotools-vector \ <2>
-	  -datastore accumulo \
-      -user USERNAME \
-      -password PASSWORD \
-	  -instance ACCUMULO_INSTANCE_NAME \
-      -zookeeper ZOOKEEPER_HOST_NAME:2181
+$ geowave config addstore -t accumulo mystore \ <1>
+      --gwNamespace geowave.50m_admin_0_countries \ <2>
+      --zookeeper ZOOKEEPER_HOSTNAME:2181 \
+      --instance ACCUMULO_INSTANCE_NAME \
+      --user USERNAME \
+      --password PASSWORD
+$ geowave config addindex -t spatial myindex \ <3>
+      --partitionStrategy round_robin \
+	  --numPartitions NUM_PARTITIONS \ <4>
+$ geowave ingest localtogw ./ingest mystore myindex \ <5>
+	  -f geotools-vector \ <6>
+
 ----
-<1> We preface the table name with the Accumulo namespace we configured earlier in the Accumulo configuration section followed by a dot (NAMESPACE.TABLE_NAME)
-<2> Explicitly set the ingest formats by name (or multiple comma-delimited formats), if not set all available ingest formats will be used
+<1> This will create a re-usable named configuration `mystore` that can be referenced as a store by other commandline operations such as ingest
+<2> We preface the table name with the Accumulo namespace we configured earlier in the Accumulo configuration section followed by a dot (NAMESPACE.TABLE_NAME)
+<3> This will create a re-usable named configuration `myindex` that can be referenced as an index by other commandline operations such as ingest
+<4> The index is spatial and pre-split based on the number of partitions you may desire - this is an optional parameter but an example of customization you may choose on index configuration, in this case data is randomized into different splits which can help avoid hotspotting to a single node/core
+<5> Notice the ingest command uses the named configurations `mystore` and `myindex`
+<6> Explicitly set the ingest formats by name (or multiple comma-delimited formats), if not set all available ingest formats will be used
+
 
 After running the ingest command you should see the various index tables in Accumulo

--- a/docs/content/055-ingestplugins.adoc
+++ b/docs/content/055-ingestplugins.adoc
@@ -1,22 +1,52 @@
 [[ingest-plugins]]
 === Ingest Plugins
 
-The geowave command line utility comes with several plugins out of the box
+The geowave command line utility comes with several plugins out of the box.  You can list the available plugins that are registered with your commandline tool and you can add more by simply copying a desired plugin into the /usr/local/geowave/tools/plugins directory.
 
 [source, bash]
 ----
-geowave -localingest --list
-Available ingest types currently registered as plugins:
+geowave ingest listplugins
 
-tdrive:
-     files from Microsoft Research T-Drive trajectory data set
+Available index types currently registered as plugins:
 
-geotools:
-     all file-based datastores supported within geotools
+  spatial_temporal:
+    This dimensionality type matches all indices that only require Geometry and Time.
 
-geolife:
-     files from Microsoft Research GeoLife trajectory data set
+  spatial:
+    This dimensionality type matches all indices that only require Geometry.
 
-gpx:
-     xml files adhering to the schema of gps exchange format
+Available ingest formats currently registered as plugins:
+
+  geotools-vector:
+    all file-based vector datastores supported within geotools
+
+  geolife:
+    files from Microsoft Research GeoLife trajectory data set
+
+  gdelt:
+    files from Google Ideas GDELT data set
+
+  stanag4676:
+    xml files representing track data that adheres to the schema defined by STANAG-4676
+
+  geotools-raster:
+    all file-based raster formats supported within geotools
+
+  gpx:
+    xml files adhering to the schema of gps exchange format
+
+  tdrive:
+    files from Microsoft Research T-Drive trajectory data set
+
+  avro:
+    This can read an Avro file encoded with the SimpleFeatureCollection schema.  This schema is also used by the export tool, so this format handles re-ingesting exported datasets.
+
+Available datastores currently registered:
+
+  accumulo:
+    A GeoWave store backed by tables in Apache Accumulo
+
+  hbase:
+    A GeoWave store backed by tables in Apache HBase
+
 ----

--- a/docs/content/057-ingeststats.adoc
+++ b/docs/content/057-ingeststats.adoc
@@ -8,7 +8,8 @@ the configuration.
 ==== Example
 [source]
 ----
-geowave -DSIMPLE_FEATURE_CONFIG_FILE=myconfigfile.json -localingest
+$ GEOWAVE_TOOL_JAVA_OPT="-DSIMPLE_FEATURE_CONFIG_FILE=myconfigfile.json"
+$ geowave ingest localtogw ./ingest mystore myindex
 ----
 
 Configuration consists of several parts:


### PR DESCRIPTION
I didn't touch DBSCAN which is mentioned in #737 because I know @rwgdrummer and @datasedai are doing a scrub of the analytics documentation, but the other issues in the documentation are covered in this