### PR TITLE
fixed concurrency issue in position map

### DIFF
--- a/extensions/adapters/vector/src/main/java/mil/nga/giat/geowave/adapter/vector/FeatureDataAdapter.java
+++ b/extensions/adapters/vector/src/main/java/mil/nga/giat/geowave/adapter/vector/FeatureDataAdapter.java
@@ -707,7 +707,7 @@ public class FeatureDataAdapter extends
 			final AttributeDescriptor ad = reprojectedType.getDescriptor(i);
 			final ByteArrayId currFieldId = new ByteArrayId(
 					ad.getLocalName());
-			fieldToPositionMap.put(
+			fieldToPositionMap.forcePut(
 					currFieldId,
 					i);
 		}


### PR DESCRIPTION
with multi-threaded ingest previous implementation has a race condition that can result in non-deterministic exceptions of this form:
java.lang.IllegalArgumentException: value already present: 29
	at com.google.common.collect.HashBiMap.put(HashBiMap.java:246)
	at com.google.common.collect.HashBiMap.put(HashBiMap.java:223)
	at mil.nga.giat.geowave.adapter.vector.FeatureDataAdapter.initializePositionMaps(FeatureDataAdapter.java:710)

calling forcePut should at least circumvent this issue