### PR TITLE
temporary fix for missing xuggler artifact

### DIFF
--- a/extensions/formats/stanag4676/format/pom.xml
+++ b/extensions/formats/stanag4676/format/pom.xml
@@ -29,16 +29,5 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
-		<dependency>
-			<groupId>xuggle</groupId>
-			<artifactId>xuggle-xuggler</artifactId>
-			<version>5.4</version>
-		</dependency>
 	</dependencies>
-	<repositories>
-		<repository>
-			<id>xuggle repo</id>
-			<url>http://xuggle.googlecode.com/svn/trunk/repo/share/java/</url>
-		</repository>
-	</repositories>
 </project>

--- a/extensions/formats/stanag4676/service/pom.xml
+++ b/extensions/formats/stanag4676/service/pom.xml
@@ -23,6 +23,11 @@
 			<artifactId>jersey-container-servlet</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>xuggle</groupId>
+			<artifactId>xuggle-xuggler</artifactId>
+			<version>5.4</version>
+		</dependency>
+		<dependency>
 			<groupId>javax.servlet</groupId>
 			<artifactId>javax.servlet-api</artifactId>
 			<version>3.0.1</version>
@@ -86,6 +91,12 @@
 			</exclusions>
 		</dependency>
 	</dependencies>
+	<repositories>
+		<repository>
+			<id>xuggle repo</id>
+			<url>http://xuggle.googlecode.com/svn/trunk/repo/share/java/</url>
+		</repository>
+	</repositories>
 	<build>
 		<plugins>
 			<plugin>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -23,7 +23,7 @@
 		<module>formats/gdelt</module>
 		<module>formats/avro</module>
 		<module>formats/stanag4676/format</module>
-		<module>formats/stanag4676/service</module>
+		<!--ignored until xuggler is resolved <module>formats/stanag4676/service</module>-->
 		<module>cli/debug</module>
 		<module>cli/osm</module>
 	</modules>


### PR DESCRIPTION
xuggler is really only necessary for the 4676 webapp and should be pulled out as a dependency from the format regardless...and let's just for now make the webapp not part of the default build process because the maven repository hosting xuggler recently broke us