### PR TITLE
Add Default Constructor for IndexOnlySpatialQuery

### DIFF
--- a/extensions/adapters/raster/src/main/java/mil/nga/giat/geowave/adapter/raster/query/IndexOnlySpatialQuery.java
+++ b/extensions/adapters/raster/src/main/java/mil/nga/giat/geowave/adapter/raster/query/IndexOnlySpatialQuery.java
@@ -26,6 +26,10 @@ public class IndexOnlySpatialQuery extends
 				queryGeometry);
 	}
 
+	public IndexOnlySpatialQuery() {
+		super();
+	}
+
 	@Override
 	public DistributableQueryFilter createQueryFilter(
 			final MultiDimensionalNumericData constraints,


### PR DESCRIPTION
In this changeset, a default constructor is added to the `IndexOnlySpatialQuery` class.  Without such a constructor, attempting to perform a query using the `newAPIHadoopRDD`/`GeoWaveIngestFormat` mechanism[1] raises an exception[2].

1. 
```
sc.newAPIHadoopRDD(
  config,
  classOf[GeoWaveInputFormat[GridCoverage2D]],
  classOf[GeoWaveInputKey],
  classOf[GridCoverage2D]);
```

2.
```
        at java.lang.Class.getConstructor0(Class.java:3082)
        at java.lang.Class.getDeclaredConstructor(Class.java:2178)
        at mil.nga.giat.geowave.core.index.PersistenceUtils.classFactory(PersistenceUtils.java:121)
        at mil.nga.giat.geowave.core.index.PersistenceUtils.fromBinary(PersistenceUtils.java:91)
        at mil.nga.giat.geowave.mapreduce.input.GeoWaveInputConfigurator.getQueryInternal(GeoWaveInputConfigurator.java:41)
        at mil.nga.giat.geowave.mapreduce.input.GeoWaveInputConfigurator.getQuery(GeoWaveInputConfigurator.java:117)
        at mil.nga.giat.geowave.mapreduce.input.GeoWaveInputFormat.getQuery(GeoWaveInputFormat.java:121)
        at mil.nga.giat.geowave.mapreduce.input.GeoWaveInputFormat.createRecordReader(GeoWaveInputFormat.java:211)
        at org.apache.spark.rdd.NewHadoopRDD$$anon$1.<init>(NewHadoopRDD.scala:156)
        at org.apache.spark.rdd.NewHadoopRDD.compute(NewHadoopRDD.scala:129)
        at org.apache.spark.rdd.NewHadoopRDD.compute(NewHadoopRDD.scala:64)
        at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:306)
        at org.apache.spark.rdd.RDD.iterator(RDD.scala:270)
        at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:66)
        at org.apache.spark.scheduler.Task.run(Task.scala:89)
        at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:214)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
        at java.lang.Thread.run(Thread.java:745)
```
