### PR TITLE
Fix: Computation of Raster Metadata Value Length

### DIFF
--- a/extensions/adapters/raster/src/main/java/mil/nga/giat/geowave/adapter/raster/adapter/RasterDataAdapter.java
+++ b/extensions/adapters/raster/src/main/java/mil/nga/giat/geowave/adapter/raster/adapter/RasterDataAdapter.java
@@ -1390,7 +1390,7 @@ public class RasterDataAdapter implements
 			final ByteBuffer entryBuf = ByteBuffer.wrap(entryBinary);
 			final int keyLength = entryBuf.getInt();
 			final byte[] keyBinary = new byte[keyLength];
-			final byte[] valueBinary = new byte[entryBinary.length - keyLength];
+			final byte[] valueBinary = new byte[entryBinary.length - keyLength - 4];
 			entryBuf.get(keyBinary);
 			entryBuf.get(valueBinary);
 			metadata.put(

--- a/test/src/test/java/mil/nga/giat/geowave/test/GeoWaveRasterIT.java
+++ b/test/src/test/java/mil/nga/giat/geowave/test/GeoWaveRasterIT.java
@@ -491,6 +491,7 @@ public class GeoWaveRasterIT
 				basicAdapter,
 				coverageName,
 				mergeStrategy);
+		basicAdapter.getMetadata().put("test-key","test-value");
 		try (IndexWriter writer = dataStore.createWriter(
 				mergeStrategyOverriddenAdapter,
 				TestUtils.DEFAULT_ALLTIER_SPATIAL_INDEX)) {


### PR DESCRIPTION
It appears that the [length of raster metadata values](https://github.com/ngageoint/geowave/blob/56bf12867340c433b789b741e42b51c07c5405a5/extensions/adapters/raster/src/main/java/mil/nga/giat/geowave/adapter/raster/adapter/RasterDataAdapter.java#L1393) is currently being computed incorrectly.  The line `valueBinary = new byte[entryBinary.length - keyLength]` produces an array which is four bytes longer than the actual number of available bytes because the subtraction does not account for the length of the 32-bit integer which is also included in the entry.

That results in errors such as this:
```
Exception in thread "main" java.nio.BufferUnderflowException
        at java.nio.HeapByteBuffer.get(HeapByteBuffer.java:151)
        at java.nio.ByteBuffer.get(ByteBuffer.java:715)
        at mil.nga.giat.geowave.adapter.raster.adapter.RasterDataAdapter.fromBinary(RasterDataAdapter.java:1395)
        at mil.nga.giat.geowave.core.index.PersistenceUtils.fromBinary(PersistenceUtils.java:96)
        at mil.nga.giat.geowave.datastore.accumulo.metadata.AbstractAccumuloPersistence.entryToValue(AbstractAccumuloPersistence.java:365)
        at mil.nga.giat.geowave.datastore.accumulo.metadata.AbstractAccumuloPersistence$NativeIteratorWrapper.next(AbstractAccumuloPersistence.java:573)
        at mil.nga.giat.geowave.datastore.accumulo.metadata.AbstractAccumuloPersistence$NativeIteratorWrapper.next(AbstractAccumuloPersistence.java:556)
        at mil.nga.giat.geowave.core.store.CloseableIteratorWrapper.next(CloseableIteratorWrapper.java:64)
```

The present patch attempts to address this issue.