### PR TITLE
Add Release Plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 	</distributionManagement>
 	<scm>
 		<url>https://github.com/ngageoint/geowave.git</url>
-		<connection>scm:git:git@github.com:ngageoint/geowave.git</connection>
+		<connection>scm:git:https://github.com/ngageoint/geowave.git</connection>
 	</scm>
 	<properties>
 		<geotools.version>14.2</geotools.version>
@@ -706,6 +706,28 @@
 					</execution>
 				</executions>
 			</plugin>
+			<!-- for incrementing version numbers and tagging repositories 
+			To Use:
+			0. Ensure all files checked into master (clean environment).  Make sure
+			   you have access to both mvn and git on your command line, and you are
+			   in a terminal that has push access (credentials are setup and correct).
+			   Make sure you have the branch active in git you want to tag.
+			   If something goes wrong pushing, you will most likely have outstanding
+			   commits in your local repo you will have to revert/remove.
+			1. mvn release:prepare -DdryRun=true 
+			2. Inspect and ensure the correct pom.xml files will be modified
+			3. mvn release:prepare
+			4. mvn release:clean
+			-->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-release-plugin</artifactId>
+				<version>2.5.3</version>
+				<configuration>
+			        <tagNameFormat>v@{project.version}</tagNameFormat>
+					<autoVersionSubmodules>true</autoVersionSubmodules>
+				</configuration>
+			</plugin>			
 		</plugins>
 	</build>
 	<modules>


### PR DESCRIPTION
Use Maven Release Plugin to Increment Version Numbers on Release

To use (instructions also included in pom file above plugin):
mvn release:prepare

Version Number, Tag Name, and next Snapshot Name will need to be selected.  Sensible defaults matching our semantic versioning scheme are pre-populated.  Use -B to use default and run non-interactively.

Performs 3 actions:
- All pom files are updated with release version & pushed to repo
- repo is tagged
- All pom files are updated with next snapshot version