### PR TITLE
fixed KDE to tileSize 1 and added tile resize as post process

### DIFF
--- a/analytics/mapreduce/src/main/java/mil/nga/giat/geowave/analytic/mapreduce/kde/GaussianCellMapper.java
+++ b/analytics/mapreduce/src/main/java/mil/nga/giat/geowave/analytic/mapreduce/kde/GaussianCellMapper.java
@@ -25,7 +25,6 @@ public class GaussianCellMapper extends
 	protected static final String CQL_FILTER_KEY = "CQL_FILTER";
 	protected int minLevel;
 	protected int maxLevel;
-	protected int tileSize;
 	protected Filter filter;
 	protected Map<Integer, LevelStore> levelStoreMap;
 
@@ -41,9 +40,6 @@ public class GaussianCellMapper extends
 		maxLevel = context.getConfiguration().getInt(
 				KDEJobRunner.MAX_LEVEL_KEY,
 				25);
-		tileSize = context.getConfiguration().getInt(
-				KDEJobRunner.TILE_SIZE_KEY,
-				1);
 		final String cql = context.getConfiguration().get(
 				CQL_FILTER_KEY);
 		if ((cql != null) && !cql.isEmpty()) {
@@ -61,10 +57,10 @@ public class GaussianCellMapper extends
 		for (int level = maxLevel; level >= minLevel; level--) {
 			final int numXPosts = (int) Math.pow(
 					2,
-					level + 1) * tileSize;
+					level + 1) * KDEJobRunner.TILE_SIZE;
 			final int numYPosts = (int) Math.pow(
 					2,
-					level) * tileSize;
+					level) * KDEJobRunner.TILE_SIZE;
 			populateLevelStore(
 					context,
 					numXPosts,

--- a/analytics/mapreduce/src/main/java/mil/nga/giat/geowave/analytic/mapreduce/kde/KDECommandLineOptions.java
+++ b/analytics/mapreduce/src/main/java/mil/nga/giat/geowave/analytic/mapreduce/kde/KDECommandLineOptions.java
@@ -18,10 +18,10 @@ public class KDECommandLineOptions
 	@Parameter(names = "--maxLevel", required = true, description = "The max level to run a KDE at")
 	private Integer maxLevel;
 
-	@Parameter(names = "--minSplits", required = true, description = "The min partitions for the input data")
+	@Parameter(names = "--minSplits", description = "The min partitions for the input data")
 	private Integer minSplits;
 
-	@Parameter(names = "--maxSplits", required = true, description = "The max partitions for the input data")
+	@Parameter(names = "--maxSplits", description = "The max partitions for the input data")
 	private Integer maxSplits;
 
 	@Parameter(names = "--coverageName", required = true, description = "The coverage name")
@@ -33,8 +33,8 @@ public class KDECommandLineOptions
 	@Parameter(names = "--jobSubmissionHostPort", required = true, description = "The job submission tracker")
 	private String jobTrackerOrResourceManHostPort;
 
-	@Parameter(names = "--tileSize", required = true, description = "The tile size")
-	private Integer tileSize;
+	@Parameter(names = "--tileSize", description = "The tile size")
+	private Integer tileSize = 1;
 
 	@Parameter(names = "--cqlFilter", description = "An optional CQL filter applied to the input data")
 	private String cqlFilter;

--- a/analytics/mapreduce/src/main/java/mil/nga/giat/geowave/analytic/mapreduce/kde/compare/ComparisonAccumuloStatsReducer.java
+++ b/analytics/mapreduce/src/main/java/mil/nga/giat/geowave/analytic/mapreduce/kde/compare/ComparisonAccumuloStatsReducer.java
@@ -41,6 +41,7 @@ public class ComparisonAccumuloStatsReducer extends
 		1,
 		1
 	};
+	private static final int TILE_SIZE = 1;
 	private long totalKeys = 0;
 	private long currentKey;
 
@@ -51,7 +52,6 @@ public class ComparisonAccumuloStatsReducer extends
 	private int numXPosts;
 	private int numYPosts;
 	private String coverageName;
-	private int tileSize;
 	protected List<ByteArrayId> indexList;
 
 	@Override
@@ -70,7 +70,7 @@ public class ComparisonAccumuloStatsReducer extends
 			final Point2d[] bbox = fromIndexToLL_UR(cellIndex);
 			final WritableRaster raster = RasterUtils.createRasterTypeDouble(
 					NUM_BANDS,
-					tileSize);
+					TILE_SIZE);
 			raster.setSample(
 					0,
 					0,
@@ -142,9 +142,6 @@ public class ComparisonAccumuloStatsReducer extends
 		coverageName = context.getConfiguration().get(
 				KDEJobRunner.COVERAGE_NAME_KEY,
 				"");
-		tileSize = context.getConfiguration().getInt(
-				KDEJobRunner.TILE_SIZE_KEY,
-				25);
 		numLevels = (maxLevels - minLevels) + 1;
 		level = context.getConfiguration().getInt(
 				"mapred.task.partition",

--- a/analytics/mapreduce/src/main/java/mil/nga/giat/geowave/analytic/mapreduce/kde/compare/ComparisonStatsJobRunner.java
+++ b/analytics/mapreduce/src/main/java/mil/nga/giat/geowave/analytic/mapreduce/kde/compare/ComparisonStatsJobRunner.java
@@ -33,10 +33,10 @@ public class ComparisonStatsJobRunner extends
 	private final String timeAttribute;
 
 	public ComparisonStatsJobRunner(
-			ComparisonCommandLineOptions inputOptions,
-			KDECommandLineOptions kdeCommandLineOptions,
-			DataStorePluginOptions inputDataStoreOptions,
-			DataStorePluginOptions outputDataStoreOptions ) {
+			final ComparisonCommandLineOptions inputOptions,
+			final KDECommandLineOptions kdeCommandLineOptions,
+			final DataStorePluginOptions inputDataStoreOptions,
+			final DataStorePluginOptions outputDataStoreOptions ) {
 		super(
 				kdeCommandLineOptions,
 				inputDataStoreOptions,
@@ -47,15 +47,15 @@ public class ComparisonStatsJobRunner extends
 	public static void main(
 			final String[] args )
 			throws Exception {
-		ConfigOptions opts = new ConfigOptions();
-		ComparisonCommandLineOptions comparisonOptions = new ComparisonCommandLineOptions();
+		final ConfigOptions opts = new ConfigOptions();
+		final ComparisonCommandLineOptions comparisonOptions = new ComparisonCommandLineOptions();
 
-		OperationParser parser = new OperationParser();
+		final OperationParser parser = new OperationParser();
 		parser.addAdditionalObject(opts);
 		parser.addAdditionalObject(comparisonOptions);
 
-		KdeCommand kdeCommand = new KdeCommand();
-		CommandLineOperationParams params = parser.parse(
+		final KdeCommand kdeCommand = new KdeCommand();
+		final CommandLineOperationParams params = parser.parse(
 				kdeCommand,
 				args);
 
@@ -65,7 +65,7 @@ public class ComparisonStatsJobRunner extends
 		// Don't care about output, but this will set the datastore options.
 		kdeCommand.createRunner(params);
 
-		ComparisonStatsJobRunner runner = new ComparisonStatsJobRunner(
+		final ComparisonStatsJobRunner runner = new ComparisonStatsJobRunner(
 				comparisonOptions,
 				kdeCommand.getKdeOptions(),
 				kdeCommand.getInputStoreOptions(),
@@ -91,7 +91,8 @@ public class ComparisonStatsJobRunner extends
 	@Override
 	protected boolean postJob2Actions(
 			final Configuration conf,
-			final String statsNamespace )
+			final String statsNamespace,
+			final String coverageName )
 			throws Exception {
 		final FileSystem fs = FileSystem.get(conf);
 		fs.delete(
@@ -177,9 +178,13 @@ public class ComparisonStatsJobRunner extends
 					ingester,
 					statsNamespace,
 					RasterUtils.createDataAdapterTypeDouble(
-							statsNamespace,
+							coverageName,
 							ComparisonAccumuloStatsReducer.NUM_BANDS,
-							kdeCommandLineOptions.getTileSize()),
+							1,
+							ComparisonAccumuloStatsReducer.MINS_PER_BAND,
+							ComparisonAccumuloStatsReducer.MAXES_PER_BAND,
+							ComparisonAccumuloStatsReducer.NAME_PER_BAND,
+							null),
 					new SpatialDimensionalityTypeProvider().createPrimaryIndex());
 			return ingester.waitForCompletion(true);
 
@@ -263,7 +268,8 @@ public class ComparisonStatsJobRunner extends
 	protected void setupJob2Output(
 			final Configuration conf,
 			final Job statsReducer,
-			final String statsNamespace )
+			final String statsNamespace,
+			final String coverageName )
 			throws Exception {
 		FileOutputFormat.setOutputPath(
 				statsReducer,

--- a/core/store/src/main/java/mil/nga/giat/geowave/core/store/operations/remote/options/DataStorePluginOptions.java
+++ b/core/store/src/main/java/mil/nga/giat/geowave/core/store/operations/remote/options/DataStorePluginOptions.java
@@ -45,29 +45,38 @@ public class DataStorePluginOptions extends
 	 * From the given options (like 'username', 'password') and the given
 	 * storeType (like 'accumulo'), setup this plugin options to be able to
 	 * create data stores.
-	 * 
+	 *
 	 * @param storeType
 	 * @param options
 	 */
 	public DataStorePluginOptions(
-			String storeType,
-			Map<String, String> options ) {
+			final String storeType,
+			final Map<String, String> options ) {
 		selectPlugin(storeType);
 		ConfigUtils.populateOptionsFromList(
 				getFactoryOptions(),
 				options);
 	}
 
+	public DataStorePluginOptions(
+			final String storeType,
+			final StoreFactoryFamilySpi factoryPlugin,
+			final StoreFactoryOptions factoryOptions ) {
+		this.storeType = storeType;
+		this.factoryPlugin = factoryPlugin;
+		this.factoryOptions = factoryOptions;
+	}
+
 	/**
 	 * This method will allow the user to specify the desired factory, such as
-	 * 'accumulo' or 'memory'.
+	 * 'accumulo' or 'hbase'.
 	 */
 	@Override
 	public void selectPlugin(
-			String qualifier ) {
+			final String qualifier ) {
 		storeType = qualifier;
 		if (qualifier != null) {
-			Map<String, StoreFactoryFamilySpi> factories = GeoWaveStoreFinder.getRegisteredStoreFactoryFamilies();
+			final Map<String, StoreFactoryFamilySpi> factories = GeoWaveStoreFinder.getRegisteredStoreFactoryFamilies();
 			factoryPlugin = factories.get(qualifier);
 			if (factoryPlugin == null) {
 				throw new ParameterException(
@@ -86,7 +95,7 @@ public class DataStorePluginOptions extends
 	}
 
 	public void setFactoryOptions(
-			StoreFactoryOptions factoryOptions ) {
+			final StoreFactoryOptions factoryOptions ) {
 		this.factoryOptions = factoryOptions;
 	}
 
@@ -128,12 +137,13 @@ public class DataStorePluginOptions extends
 				getFactoryOptions());
 	}
 
+	@Override
 	public String getType() {
 		return storeType;
 	}
 
 	public static String getStoreNamespace(
-			String name ) {
+			final String name ) {
 		return String.format(
 				"%s.%s",
 				DATASTORE_PROPERTY_NAMESPACE,

--- a/extensions/adapters/raster/src/main/java/mil/nga/giat/geowave/adapter/raster/RasterUtils.java
+++ b/extensions/adapters/raster/src/main/java/mil/nga/giat/geowave/adapter/raster/RasterUtils.java
@@ -81,7 +81,7 @@ import com.vividsolutions.jts.simplify.DouglasPeuckerSimplifier;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import mil.nga.giat.geowave.adapter.raster.adapter.RasterDataAdapter;
-import mil.nga.giat.geowave.adapter.raster.adapter.merge.nodata.NoDataMergeStrategy;
+import mil.nga.giat.geowave.adapter.raster.adapter.merge.RasterTileMergeStrategy;
 import mil.nga.giat.geowave.adapter.raster.plugin.GeoWaveGTRasterFormat;
 import mil.nga.giat.geowave.core.index.sfc.data.MultiDimensionalNumericData;
 
@@ -843,9 +843,22 @@ public class RasterUtils
 				coverageName,
 				numBands,
 				tileSize,
-				null,
-				null,
 				null);
+	}
+
+	public static RasterDataAdapter createDataAdapterTypeDouble(
+			final String coverageName,
+			final int numBands,
+			final int tileSize,
+			final RasterTileMergeStrategy<?> mergeStrategy ) {
+		return createDataAdapterTypeDouble(
+				coverageName,
+				numBands,
+				tileSize,
+				null,
+				null,
+				null,
+				mergeStrategy);
 	}
 
 	public static RasterDataAdapter createDataAdapterTypeDouble(
@@ -854,7 +867,8 @@ public class RasterUtils
 			final int tileSize,
 			final double[] minsPerBand,
 			final double[] maxesPerBand,
-			final String[] namesPerBand ) {
+			final String[] namesPerBand,
+			final RasterTileMergeStrategy<?> mergeStrategy ) {
 		final double[][] noDataValuesPerBand = new double[numBands][];
 		final double[] backgroundValuesPerBand = new double[numBands];
 		final int[] bitsPerSample = new int[numBands];
@@ -890,7 +904,7 @@ public class RasterUtils
 				false,
 				Interpolation.INTERP_NEAREST,
 				false,
-				new NoDataMergeStrategy());
+				mergeStrategy);
 	}
 
 	public static GridCoverage2D createCoverageTypeDouble(

--- a/extensions/adapters/raster/src/main/java/mil/nga/giat/geowave/adapter/raster/adapter/RasterDataAdapter.java
+++ b/extensions/adapters/raster/src/main/java/mil/nga/giat/geowave/adapter/raster/adapter/RasterDataAdapter.java
@@ -312,9 +312,17 @@ public class RasterDataAdapter implements
 
 	public RasterDataAdapter(
 			final RasterDataAdapter adapter,
+			final String coverageName ) {
+		this(
+				adapter,
+				coverageName,
+				adapter.tileSize);
+	}
+
+	public RasterDataAdapter(
+			final RasterDataAdapter adapter,
 			final String coverageName,
-			final int tileSize,
-			final RasterTileMergeStrategy<?> mergeStrategy ) {
+			final int tileSize ) {
 		this(
 				coverageName,
 				adapter.getSampleModel().createCompatibleSampleModel(
@@ -329,7 +337,8 @@ public class RasterDataAdapter implements
 				adapter.equalizeHistogram,
 				interpolationToByte(adapter.interpolation),
 				adapter.buildPyramid,
-				mergeStrategy);
+				adapter.mergeStrategy == null ? null : adapter.mergeStrategy.getChildMergeStrategy(adapter
+						.getAdapterId()));
 	}
 
 	public RasterDataAdapter(

--- a/extensions/adapters/raster/src/main/java/mil/nga/giat/geowave/adapter/raster/operations/options/RasterTileResizeCommandLineOptions.java
+++ b/extensions/adapters/raster/src/main/java/mil/nga/giat/geowave/adapter/raster/operations/options/RasterTileResizeCommandLineOptions.java
@@ -4,10 +4,10 @@ import com.beust.jcommander.Parameter;
 
 public class RasterTileResizeCommandLineOptions
 {
-	@Parameter(names = "--inputCoverageName", description = "The name of the feature type to run a KDE on", required = true)
+	@Parameter(names = "--inputCoverageName", description = "The name of the input raster coverage", required = true)
 	private String inputCoverageName;
 
-	@Parameter(names = "--outputCoverageName", description = "The min level to run a KDE at", required = true)
+	@Parameter(names = "--outputCoverageName", description = "The out output raster coverage name", required = true)
 	private String outputCoverageName;
 
 	@Parameter(names = "--minSplits", description = "The min partitions for the input data")
@@ -16,16 +16,16 @@ public class RasterTileResizeCommandLineOptions
 	@Parameter(names = "--maxSplits", description = "The max partitions for the input data")
 	private Integer maxSplits;
 
-	@Parameter(names = "--hdfsHostPort", description = "The max partitions for the input data", converter = HdfsHostPortConverter.class)
+	@Parameter(names = "--hdfsHostPort", description = "he hdfs host port", converter = HdfsHostPortConverter.class, required = true)
 	private String hdfsHostPort;
 
-	@Parameter(names = "--jobSubmissionHostPort", description = "The max partitions for the input data")
+	@Parameter(names = "--jobSubmissionHostPort", description = "The job submission tracker", required = true)
 	private String jobTrackerOrResourceManHostPort;
 
-	@Parameter(names = "--outputTileSize", description = "The max partitions for the input data")
+	@Parameter(names = "--outputTileSize", description = "The tile size to output", required = true)
 	private Integer outputTileSize;
 
-	@Parameter(names = "--indexId", description = "The max level to run a KDE at")
+	@Parameter(names = "--indexId", description = "The index that the input raster is stored in")
 	private String indexId;
 
 	// Default constructor

--- a/extensions/adapters/raster/src/main/java/mil/nga/giat/geowave/adapter/raster/resize/RasterTileResizeHelper.java
+++ b/extensions/adapters/raster/src/main/java/mil/nga/giat/geowave/adapter/raster/resize/RasterTileResizeHelper.java
@@ -5,8 +5,13 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapreduce.JobContext;
+import org.opengis.coverage.grid.GridCoverage;
+
 import mil.nga.giat.geowave.adapter.raster.adapter.MergeableRasterTile;
 import mil.nga.giat.geowave.adapter.raster.adapter.RasterDataAdapter;
+import mil.nga.giat.geowave.adapter.raster.adapter.merge.nodata.NoDataMergeStrategy;
 import mil.nga.giat.geowave.core.index.ByteArrayId;
 import mil.nga.giat.geowave.core.store.adapter.DataAdapter;
 import mil.nga.giat.geowave.core.store.index.PrimaryIndex;
@@ -14,10 +19,6 @@ import mil.nga.giat.geowave.mapreduce.JobContextAdapterStore;
 import mil.nga.giat.geowave.mapreduce.JobContextIndexStore;
 import mil.nga.giat.geowave.mapreduce.input.GeoWaveInputKey;
 import mil.nga.giat.geowave.mapreduce.output.GeoWaveOutputKey;
-
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.mapreduce.JobContext;
-import org.opengis.coverage.grid.GridCoverage;
 
 public class RasterTileResizeHelper
 {
@@ -42,7 +43,17 @@ public class RasterTileResizeHelper
 			}
 			else if (adapter.getAdapterId().getString().equals(
 					newAdapterId)) {
-				newAdapter = (RasterDataAdapter) adapter;
+				if (((RasterDataAdapter) adapter).getTransform() == null) {
+					// the new adapter doesn't have a merge strategy - resizing
+					// will require merging, so default to NoDataMergeStrategy
+					newAdapter = new RasterDataAdapter(
+							(RasterDataAdapter) adapter,
+							newAdapterId,
+							new NoDataMergeStrategy());
+				}
+				else {
+					newAdapter = (RasterDataAdapter) adapter;
+				}
 			}
 		}
 	}

--- a/extensions/adapters/raster/src/main/java/mil/nga/giat/geowave/adapter/raster/resize/RasterTileResizeJobRunner.java
+++ b/extensions/adapters/raster/src/main/java/mil/nga/giat/geowave/adapter/raster/resize/RasterTileResizeJobRunner.java
@@ -12,7 +12,6 @@ import org.apache.log4j.Logger;
 import org.opengis.coverage.grid.GridCoverage;
 
 import mil.nga.giat.geowave.adapter.raster.adapter.RasterDataAdapter;
-import mil.nga.giat.geowave.adapter.raster.adapter.merge.nodata.NoDataMergeStrategy;
 import mil.nga.giat.geowave.adapter.raster.operations.ResizeCommand;
 import mil.nga.giat.geowave.adapter.raster.operations.options.RasterTileResizeCommandLineOptions;
 import mil.nga.giat.geowave.core.cli.operations.config.options.ConfigOptions;
@@ -116,14 +115,13 @@ public class RasterTileResizeJobRunner extends
 		if (adapter == null) {
 			throw new IllegalArgumentException(
 					"Adapter for coverage '" + rasterResizeOptions.getInputCoverageName()
-							+ "' does not exist in namesace '" + inputStoreOptions.getGeowaveNamespace() + "'");
+							+ "' does not exist in namespace '" + inputStoreOptions.getGeowaveNamespace() + "'");
 		}
 
 		final RasterDataAdapter newAdapter = new RasterDataAdapter(
 				(RasterDataAdapter) adapter,
 				rasterResizeOptions.getOutputCoverageName(),
-				rasterResizeOptions.getOutputTileSize(),
-				new NoDataMergeStrategy());
+				rasterResizeOptions.getOutputTileSize());
 		JobContextAdapterStore.addDataAdapter(
 				job.getConfiguration(),
 				adapter);

--- a/extensions/adapters/raster/src/test/java/mil/nga/giat/geowave/adapter/raster/RasterUtilsTest.java
+++ b/extensions/adapters/raster/src/test/java/mil/nga/giat/geowave/adapter/raster/RasterUtilsTest.java
@@ -4,6 +4,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import mil.nga.giat.geowave.adapter.raster.adapter.RasterDataAdapter;
+import mil.nga.giat.geowave.adapter.raster.adapter.merge.nodata.NoDataMergeStrategy;
 
 public class RasterUtilsTest
 {
@@ -12,7 +13,8 @@ public class RasterUtilsTest
 		final RasterDataAdapter adapter = RasterUtils.createDataAdapterTypeDouble(
 				"test",
 				3,
-				256);
+				256,
+				new NoDataMergeStrategy());
 		Assert.assertNotNull(adapter);
 		Assert.assertEquals(
 				"test",

--- a/test/src/test/java/mil/nga/giat/geowave/test/GeoWaveRasterIT.java
+++ b/test/src/test/java/mil/nga/giat/geowave/test/GeoWaveRasterIT.java
@@ -5,9 +5,17 @@ import java.awt.image.SampleModel;
 import java.awt.image.WritableRaster;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Random;
+
+import org.apache.accumulo.core.client.AccumuloException;
+import org.apache.accumulo.core.client.AccumuloSecurityException;
+import org.apache.accumulo.core.client.TableNotFoundException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opengis.coverage.grid.GridCoverage;
+
+import com.vividsolutions.jts.geom.Envelope;
+import com.vividsolutions.jts.geom.GeometryFactory;
 
 import junit.framework.Assert;
 import mil.nga.giat.geowave.adapter.raster.RasterUtils;
@@ -16,6 +24,7 @@ import mil.nga.giat.geowave.adapter.raster.adapter.RasterDataAdapter;
 import mil.nga.giat.geowave.adapter.raster.adapter.RasterTile;
 import mil.nga.giat.geowave.adapter.raster.adapter.merge.RasterTileMergeStrategy;
 import mil.nga.giat.geowave.adapter.raster.adapter.merge.SimpleAbstractMergeStrategy;
+import mil.nga.giat.geowave.adapter.raster.adapter.merge.nodata.NoDataMergeStrategy;
 import mil.nga.giat.geowave.core.geotime.store.query.IndexOnlySpatialQuery;
 import mil.nga.giat.geowave.core.index.ByteArrayId;
 import mil.nga.giat.geowave.core.index.Persistable;
@@ -25,22 +34,8 @@ import mil.nga.giat.geowave.core.store.index.writer.IndexWriter;
 import mil.nga.giat.geowave.core.store.operations.remote.options.DataStorePluginOptions;
 import mil.nga.giat.geowave.core.store.query.EverythingQuery;
 import mil.nga.giat.geowave.core.store.query.QueryOptions;
-import mil.nga.giat.geowave.core.store.util.DataStoreUtils;
-import mil.nga.giat.geowave.datastore.accumulo.AccumuloDataStore;
-import mil.nga.giat.geowave.datastore.accumulo.util.ConnectorPool;
 import mil.nga.giat.geowave.test.annotation.GeoWaveTestStore;
 import mil.nga.giat.geowave.test.annotation.GeoWaveTestStore.GeoWaveStoreType;
-
-import org.apache.accumulo.core.client.AccumuloException;
-import org.apache.accumulo.core.client.AccumuloSecurityException;
-import org.apache.accumulo.core.client.Connector;
-import org.apache.accumulo.core.client.TableNotFoundException;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.opengis.coverage.grid.GridCoverage;
-
-import com.vividsolutions.jts.geom.Envelope;
-import com.vividsolutions.jts.geom.GeometryFactory;
 
 @RunWith(GeoWaveITRunner.class)
 public class GeoWaveRasterIT
@@ -280,7 +275,8 @@ public class GeoWaveRasterIT
 		final RasterDataAdapter adapter = RasterUtils.createDataAdapterTypeDouble(
 				coverageName,
 				numBands,
-				tileSize);
+				tileSize,
+				new NoDataMergeStrategy());
 		final WritableRaster raster1 = RasterUtils.createRasterTypeDouble(
 				numBands,
 				tileSize);
@@ -486,7 +482,8 @@ public class GeoWaveRasterIT
 		final RasterDataAdapter basicAdapter = RasterUtils.createDataAdapterTypeDouble(
 				coverageName,
 				numBands,
-				tileSize);
+				tileSize,
+				new NoDataMergeStrategy());
 		final RasterDataAdapter mergeStrategyOverriddenAdapter = new RasterDataAdapter(
 				basicAdapter,
 				coverageName,

--- a/test/src/test/java/mil/nga/giat/geowave/test/mapreduce/KDERasterResizeIT.java
+++ b/test/src/test/java/mil/nga/giat/geowave/test/mapreduce/KDERasterResizeIT.java
@@ -123,9 +123,9 @@ public class KDERasterResizeIT
 			command.getKdeOptions().setFeatureType(
 					KDE_FEATURE_TYPE_NAME);
 			command.getKdeOptions().setMinLevel(
-					BASE_MIN_LEVEL - i);
+					BASE_MIN_LEVEL);
 			command.getKdeOptions().setMaxLevel(
-					BASE_MAX_LEVEL - i);
+					BASE_MAX_LEVEL);
 			command.getKdeOptions().setMinSplits(
 					MapReduceTestUtils.MIN_INPUT_SPLITS);
 			command.getKdeOptions().setMaxSplits(


### PR DESCRIPTION
this allows for KDE to ignore the merging combiner and tile no data merge strategy altogether, simplifying the process, but does require a final step, reusing the raster resize command to finalize the output with the appropriately requested tile size