### PR TITLE
added geowave snapshot repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -772,6 +772,17 @@
 			<url>http://maven.geo-solutions.it</url>
 		</repository>
 		<repository>
+			<id>geowave-maven-snapshots</id>
+			<name>GeoWave AWS Snapshots Repository</name>
+			<url>http://geowave-maven.s3-website-us-east-1.amazonaws.com/snapshot</url>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</repository>
+		<repository>
 			<id>geowave-maven-releases</id>
 			<name>GeoWave AWS Release Repository</name>
 			<url>http://geowave-maven.s3-website-us-east-1.amazonaws.com/release</url>


### PR DESCRIPTION
This could be arguable, considering all snapshot artifacts can be built directly from source?  We do have the release repository linked so it seems consistent to add the snapshot as well?