### PR TITLE
Removed statement preventing execution of tests on forks

### DIFF
--- a/.utility/run-tests.sh
+++ b/.utility/run-tests.sh
@@ -1,12 +1,10 @@
 #!/bin/bash
 set -ev
 
-if [ "$TRAVIS_REPO_SLUG" == "ngageoint/geowave" ]; then
-  if [ "$IT_ONLY" == "true" ]; then
-    echo -e "Skipping unit tests w/ verify...\n"
-    mvn -q verify -Dtest=SkipUnitTests -DfailIfNoTests=false -Daccumulo.version=$ACCUMULO_VERSION -Daccumulo.api=$ACCUMULO_API -Dhbase.version=$HBASE_VERSION -Dhadoop.version=$HADOOP_VERSION -Dgeotools.version=$GEOTOOLS_VERSION -Dgeoserver.version=$GEOSERVER_VERSION -P $PLATFORM_VERSION
-  else
-    echo -e "Running unit tests only w/ verify...\n"
-    mvn -q verify -DskipITs=true -Daccumulo.version=$ACCUMULO_VERSION -Daccumulo.api=$ACCUMULO_API -Dhbase.version=$HBASE_VERSION -Dhadoop.version=$HADOOP_VERSION -Dgeotools.version=$GEOTOOLS_VERSION -Dgeoserver.version=$GEOSERVER_VERSION -P $PLATFORM_VERSION
-  fi
+if [ "$IT_ONLY" == "true" ]; then
+  echo -e "Skipping unit tests w/ verify...\n"
+  mvn -q verify -Dtest=SkipUnitTests -DfailIfNoTests=false -Daccumulo.version=$ACCUMULO_VERSION -Daccumulo.api=$ACCUMULO_API -Dhbase.version=$HBASE_VERSION -Dhadoop.version=$HADOOP_VERSION -Dgeotools.version=$GEOTOOLS_VERSION -Dgeoserver.version=$GEOSERVER_VERSION -P $PLATFORM_VERSION
+else
+  echo -e "Running unit tests only w/ verify...\n"
+  mvn -q verify -DskipITs=true -Daccumulo.version=$ACCUMULO_VERSION -Daccumulo.api=$ACCUMULO_API -Dhbase.version=$HBASE_VERSION -Dhadoop.version=$HADOOP_VERSION -Dgeotools.version=$GEOTOOLS_VERSION -Dgeoserver.version=$GEOSERVER_VERSION -P $PLATFORM_VERSION
 fi


### PR DESCRIPTION
`if [ "$TRAVIS_REPO_SLUG" == "ngageoint/geowave" ]; then` in .utility/run-tests.sh was causing Travis to skip execution of all tests on GeoWave forks

See: https://travis-ci.org/dcy2003/geowave/builds/173884588