### PR TITLE
clean up data store options api

### DIFF
--- a/analytics/api/src/main/java/mil/nga/giat/geowave/analytic/param/InputStoreParameterHelper.java
+++ b/analytics/api/src/main/java/mil/nga/giat/geowave/analytic/param/InputStoreParameterHelper.java
@@ -1,20 +1,22 @@
 package mil.nga.giat.geowave.analytic.param;
 
-import java.util.Map;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapreduce.JobContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import mil.nga.giat.geowave.analytic.PropertyManagement;
 import mil.nga.giat.geowave.analytic.store.PersistableStore;
 import mil.nga.giat.geowave.core.store.operations.remote.options.DataStorePluginOptions;
 import mil.nga.giat.geowave.mapreduce.input.GeoWaveInputFormat;
 
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.mapreduce.JobContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 public class InputStoreParameterHelper implements
 		ParameterHelper<PersistableStore>
 {
+	/**
+	 *
+	 */
+	private static final long serialVersionUID = 1L;
 	final static Logger LOGGER = LoggerFactory.getLogger(InputStoreParameterHelper.class);
 
 	@Override
@@ -28,12 +30,9 @@ public class InputStoreParameterHelper implements
 			final Class<?> scope,
 			final PersistableStore value ) {
 		final DataStorePluginOptions options = value.getDataStoreOptions();
-		GeoWaveInputFormat.setDataStoreName(
+		GeoWaveInputFormat.setStoreOptions(
 				config,
-				options.getType());
-		GeoWaveInputFormat.setStoreConfigOptions(
-				config,
-				options.getFactoryOptionsAsMap());
+				options);
 
 	}
 
@@ -42,13 +41,8 @@ public class InputStoreParameterHelper implements
 			final JobContext context,
 			final Class<?> scope,
 			final PersistableStore defaultValue ) {
-		final Map<String, String> configOptions = GeoWaveInputFormat.getStoreConfigOptions(context);
-		final String dataStoreName = GeoWaveInputFormat.getDataStoreName(context);
-		if ((dataStoreName != null) && (!dataStoreName.isEmpty())) {
-			// Load the plugin, and populate the options object.
-			DataStorePluginOptions pluginOptions = new DataStorePluginOptions(
-					dataStoreName,
-					configOptions);
+		final DataStorePluginOptions pluginOptions = GeoWaveInputFormat.getStoreOptions(context);
+		if (pluginOptions != null) {
 			return new PersistableStore(
 					pluginOptions);
 		}

--- a/analytics/api/src/main/java/mil/nga/giat/geowave/analytic/param/OutputStoreParameterHelper.java
+++ b/analytics/api/src/main/java/mil/nga/giat/geowave/analytic/param/OutputStoreParameterHelper.java
@@ -1,8 +1,5 @@
 package mil.nga.giat.geowave.analytic.param;
 
-import java.util.Map;
-
-import org.apache.directory.api.util.exception.NotImplementedException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapreduce.JobContext;
 import org.slf4j.Logger;
@@ -11,12 +8,15 @@ import org.slf4j.LoggerFactory;
 import mil.nga.giat.geowave.analytic.PropertyManagement;
 import mil.nga.giat.geowave.analytic.store.PersistableStore;
 import mil.nga.giat.geowave.core.store.operations.remote.options.DataStorePluginOptions;
-import mil.nga.giat.geowave.mapreduce.input.GeoWaveInputFormat;
 import mil.nga.giat.geowave.mapreduce.output.GeoWaveOutputFormat;
 
 public class OutputStoreParameterHelper implements
 		ParameterHelper<PersistableStore>
 {
+	/**
+	 *
+	 */
+	private static final long serialVersionUID = 1L;
 	final static Logger LOGGER = LoggerFactory.getLogger(OutputStoreParameterHelper.class);
 
 	@Override
@@ -30,12 +30,9 @@ public class OutputStoreParameterHelper implements
 			final Class<?> scope,
 			final PersistableStore value ) {
 		final DataStorePluginOptions options = value.getDataStoreOptions();
-		GeoWaveOutputFormat.setDataStoreName(
+		GeoWaveOutputFormat.setStoreOptions(
 				config,
-				options.getType());
-		GeoWaveOutputFormat.setStoreConfigOptions(
-				config,
-				options.getFactoryOptionsAsMap());
+				options);
 
 	}
 
@@ -44,13 +41,8 @@ public class OutputStoreParameterHelper implements
 			final JobContext context,
 			final Class<?> scope,
 			final PersistableStore defaultValue ) {
-		final Map<String, String> configOptions = GeoWaveOutputFormat.getStoreConfigOptions(context);
-		final String dataStoreName = GeoWaveOutputFormat.getDataStoreName(context);
-		if ((dataStoreName != null) && (!dataStoreName.isEmpty())) {
-			// Load the plugin, and populate the options object.
-			DataStorePluginOptions pluginOptions = new DataStorePluginOptions(
-					dataStoreName,
-					configOptions);
+		final DataStorePluginOptions pluginOptions = GeoWaveOutputFormat.getStoreOptions(context);
+		if (pluginOptions != null) {
 			return new PersistableStore(
 					pluginOptions);
 		}

--- a/analytics/mapreduce/src/main/java/mil/nga/giat/geowave/analytic/mapreduce/GeoWaveInputFormatConfiguration.java
+++ b/analytics/mapreduce/src/main/java/mil/nga/giat/geowave/analytic/mapreduce/GeoWaveInputFormatConfiguration.java
@@ -41,12 +41,9 @@ public class GeoWaveInputFormatConfiguration implements
 			throws Exception {
 		final DataStorePluginOptions dataStoreOptions = ((PersistableStore) runTimeProperties
 				.getProperty(StoreParam.INPUT_STORE)).getDataStoreOptions();
-		GeoWaveInputFormat.setDataStoreName(
+		GeoWaveInputFormat.setStoreOptions(
 				configuration,
-				dataStoreOptions.getType());
-		GeoWaveInputFormat.setStoreConfigOptions(
-				configuration,
-				dataStoreOptions.getFactoryOptionsAsMap());
+				dataStoreOptions);
 
 		final DistributableQuery query = runTimeProperties.getPropertyAsQuery(ExtractParameters.Extract.QUERY);
 

--- a/analytics/mapreduce/src/main/java/mil/nga/giat/geowave/analytic/mapreduce/GeoWaveOutputFormatConfiguration.java
+++ b/analytics/mapreduce/src/main/java/mil/nga/giat/geowave/analytic/mapreduce/GeoWaveOutputFormatConfiguration.java
@@ -31,12 +31,9 @@ public class GeoWaveOutputFormatConfiguration implements
 			throws Exception {
 		final DataStorePluginOptions dataStoreOptions = ((PersistableStore) runTimeProperties
 				.getProperty(StoreParam.INPUT_STORE)).getDataStoreOptions();
-		GeoWaveOutputFormat.setDataStoreName(
+		GeoWaveOutputFormat.setStoreOptions(
 				configuration,
-				dataStoreOptions.getType());
-		GeoWaveOutputFormat.setStoreConfigOptions(
-				configuration,
-				dataStoreOptions.getFactoryOptionsAsMap());
+				dataStoreOptions);
 	}
 
 	@Override

--- a/analytics/mapreduce/src/main/java/mil/nga/giat/geowave/analytic/mapreduce/clustering/runner/GeoWaveAnalyticExtractJobRunner.java
+++ b/analytics/mapreduce/src/main/java/mil/nga/giat/geowave/analytic/mapreduce/clustering/runner/GeoWaveAnalyticExtractJobRunner.java
@@ -222,19 +222,13 @@ public class GeoWaveAnalyticExtractJobRunner extends
 		setQueryOptions(runTimeProperties.getPropertyAsQueryOptions(ExtractParameters.Extract.QUERY_OPTIONS));
 		dataStoreOptions = store.getDataStoreOptions();
 
-		GeoWaveInputFormat.setDataStoreName(
+		GeoWaveInputFormat.setStoreOptions(
 				config,
-				dataStoreOptions.getType());
-		GeoWaveInputFormat.setStoreConfigOptions(
-				config,
-				dataStoreOptions.getFactoryOptionsAsMap());
+				dataStoreOptions);
 
-		GeoWaveOutputFormat.setDataStoreName(
+		GeoWaveOutputFormat.setStoreOptions(
 				config,
-				dataStoreOptions.getType());
-		GeoWaveOutputFormat.setStoreConfigOptions(
-				config,
-				dataStoreOptions.getFactoryOptionsAsMap());
+				dataStoreOptions);
 
 		try (final FileSystem fs = FileSystem.get(config)) {
 			if (fs.exists(this.getHdfsOutputPath())) {

--- a/analytics/mapreduce/src/main/java/mil/nga/giat/geowave/analytic/mapreduce/clustering/runner/GroupAssigmentJobRunner.java
+++ b/analytics/mapreduce/src/main/java/mil/nga/giat/geowave/analytic/mapreduce/clustering/runner/GroupAssigmentJobRunner.java
@@ -73,12 +73,9 @@ public class GroupAssigmentJobRunner extends
 		// the adapter
 		final DataStorePluginOptions dataStoreOptions = ((PersistableStore) runTimeProperties
 				.getProperty(StoreParam.INPUT_STORE)).getDataStoreOptions();
-		GeoWaveInputFormat.setDataStoreName(
+		GeoWaveInputFormat.setStoreOptions(
 				config,
-				dataStoreOptions.getType());
-		GeoWaveInputFormat.setStoreConfigOptions(
-				config,
-				dataStoreOptions.getFactoryOptionsAsMap());
+				dataStoreOptions);
 		runTimeProperties.setConfig(
 				new ParameterEnum[] {
 					CentroidParameters.Centroid.EXTRACTOR_CLASS,

--- a/analytics/mapreduce/src/main/java/mil/nga/giat/geowave/analytic/mapreduce/kde/KDEJobRunner.java
+++ b/analytics/mapreduce/src/main/java/mil/nga/giat/geowave/analytic/mapreduce/kde/KDEJobRunner.java
@@ -31,7 +31,6 @@ import org.slf4j.LoggerFactory;
 import com.vividsolutions.jts.geom.Geometry;
 
 import mil.nga.giat.geowave.adapter.raster.RasterUtils;
-import mil.nga.giat.geowave.adapter.raster.adapter.merge.nodata.NoDataMergeStrategy;
 import mil.nga.giat.geowave.adapter.raster.operations.ResizeCommand;
 import mil.nga.giat.geowave.adapter.vector.plugin.ExtractGeometryFilterVisitor;
 import mil.nga.giat.geowave.analytic.mapreduce.operations.KdeCommand;
@@ -108,14 +107,12 @@ public class KDEJobRunner extends
 
 			// first clone the outputDataStoreOptions, then set it to a tmp
 			// namespace
-			final Map<String, String> configOptions = outputDataStoreOptions.getFactoryOptionsAsMap();
+			final Map<String, String> configOptions = outputDataStoreOptions.getOptionsAsMap();
 			final StoreFactoryOptions options = ConfigUtils.populateOptionsFromList(
 					outputDataStoreOptions.getFactoryFamily().getDataStoreFactory().createOptionsInstance(),
 					configOptions);
 			options.setGeowaveNamespace(outputDataStoreOptions.getGeowaveNamespace() + "_tmp");
 			outputDataStoreOptions = new DataStorePluginOptions(
-					outputDataStoreOptions.getType(),
-					outputDataStoreOptions.getFactoryFamily(),
 					options);
 			kdeCoverageName = kdeCommandLineOptions.getCoverageName() + TMP_COVERAGE_SUFFIX;
 		}
@@ -189,12 +186,9 @@ public class KDEJobRunner extends
 				job.getConfiguration(),
 				kdeCommandLineOptions.getMaxSplits());
 
-		GeoWaveInputFormat.setDataStoreName(
+		GeoWaveInputFormat.setStoreOptions(
 				job.getConfiguration(),
-				inputDataStoreOptions.getType());
-		GeoWaveInputFormat.setStoreConfigOptions(
-				job.getConfiguration(),
-				inputDataStoreOptions.getFactoryOptionsAsMap());
+				inputDataStoreOptions);
 
 		if (kdeCommandLineOptions.getCqlFilter() != null) {
 			final Filter filter = ECQL.toFilter(kdeCommandLineOptions.getCqlFilter());
@@ -333,7 +327,9 @@ public class KDEJobRunner extends
 			return (job1Success && job2Success && postJob2Success) ? 0 : 1;
 		}
 		finally {
-			if (fs != null) fs.close();
+			if (fs != null) {
+				fs.close();
+			}
 		}
 	}
 
@@ -437,12 +433,9 @@ public class KDEJobRunner extends
 			final PrimaryIndex index )
 			throws IOException,
 			MismatchedIndexToAdapterMapping {
-		GeoWaveOutputFormat.setDataStoreName(
+		GeoWaveOutputFormat.setStoreOptions(
 				job.getConfiguration(),
-				outputDataStoreOptions.getType());
-		GeoWaveOutputFormat.setStoreConfigOptions(
-				job.getConfiguration(),
-				outputDataStoreOptions.getFactoryOptionsAsMap());
+				outputDataStoreOptions);
 
 		GeoWaveOutputFormat.addDataAdapter(
 				job.getConfiguration(),

--- a/analytics/mapreduce/src/main/java/mil/nga/giat/geowave/analytic/mapreduce/kde/compare/ComparisonStatsJobRunner.java
+++ b/analytics/mapreduce/src/main/java/mil/nga/giat/geowave/analytic/mapreduce/kde/compare/ComparisonStatsJobRunner.java
@@ -170,12 +170,9 @@ public class ComparisonStatsJobRunner extends
 										+ kdeCommandLineOptions.getMinLevel() + "_"
 										+ kdeCommandLineOptions.getMaxLevel() + "_"
 										+ kdeCommandLineOptions.getCoverageName() + "/combined_pct"));
-				GeoWaveOutputFormat.setDataStoreName(
+				GeoWaveOutputFormat.setStoreOptions(
 						conf,
-						outputDataStoreOptions.getType());
-				GeoWaveOutputFormat.setStoreConfigOptions(
-						conf,
-						outputDataStoreOptions.getFactoryOptionsAsMap());
+						outputDataStoreOptions);
 
 				setup(
 						ingester,

--- a/analytics/mapreduce/src/main/java/mil/nga/giat/geowave/analytic/mapreduce/kmeans/runner/KMeansDistortionJobRunner.java
+++ b/analytics/mapreduce/src/main/java/mil/nga/giat/geowave/analytic/mapreduce/kmeans/runner/KMeansDistortionJobRunner.java
@@ -77,12 +77,9 @@ public class KMeansDistortionJobRunner extends
 
 		// Required since the Mapper uses the input format parameters to lookup
 		// the adapter
-		GeoWaveInputFormat.setDataStoreName(
+		GeoWaveInputFormat.setStoreOptions(
 				conf,
-				dataStoreOptions.getType());
-		GeoWaveInputFormat.setStoreConfigOptions(
-				conf,
-				dataStoreOptions.getFactoryOptionsAsMap());
+				dataStoreOptions);
 
 		GeoWaveOutputFormat.addDataAdapter(
 				conf,

--- a/analytics/spark/src/main/scala/mil/nga/giat/geowave/analytics/spark/GeoWaveContext.scala
+++ b/analytics/spark/src/main/scala/mil/nga/giat/geowave/analytics/spark/GeoWaveContext.scala
@@ -13,7 +13,7 @@ object GeoWaveContext {
 	def apply(dataStoreOptions: DataStorePluginOptions,
 						dataStoreName: String,
 						tableNameSpace: String) = new GeoWaveContext(
-		ConfigUtils.populateListFromOptions(dataStoreOptions.getFactoryOptions),
+		dataStoreOptions.getOptionsAsMap,
 		dataStoreName,
 		tableNameSpace);
 

--- a/analytics/spark/src/main/scala/mil/nga/giat/geowave/analytics/spark/GeoWaveRDD.scala
+++ b/analytics/spark/src/main/scala/mil/nga/giat/geowave/analytics/spark/GeoWaveRDD.scala
@@ -60,10 +60,7 @@ object GeoWaveRDD {
 
     val conf = new org.apache.hadoop.conf.Configuration(sc.hadoopConfiguration)
 
-    GeoWaveInputFormat.setDataStoreName(conf,
-      geoWaveContext.dataStoreName)
-
-    GeoWaveInputFormat.setStoreConfigOptions(conf,
+    GeoWaveInputFormat.setStoreOptionsMap(conf,
       geoWaveContext.storeParameters)
 
     // index and adapters are not mandatory.
@@ -104,10 +101,8 @@ object GeoWaveRDD {
     //setup the configuration and the output format
     val conf = new org.apache.hadoop.conf.Configuration(sc.hadoopConfiguration)
 
-    GeoWaveOutputFormat.setDataStoreName(conf,
-      geoWaveContext.dataStoreName)
 
-    GeoWaveOutputFormat.setStoreConfigOptions(conf,
+    GeoWaveOutputFormat.setStoreOptionsMap(conf,
       geoWaveContext.storeParameters)
 
     GeoWaveOutputFormat.addIndex(conf, index)

--- a/core/cli/src/main/java/mil/nga/giat/geowave/core/cli/api/PluginOptions.java
+++ b/core/cli/src/main/java/mil/nga/giat/geowave/core/cli/api/PluginOptions.java
@@ -7,16 +7,16 @@ import java.util.Properties;
  */
 public interface PluginOptions
 {
-	String getType();
+	public String getType();
 
-	void selectPlugin(
+	public void selectPlugin(
 			String qualifier );
 
-	void save(
+	public void save(
 			Properties properties,
 			String namespace );
 
-	boolean load(
+	public boolean load(
 			Properties properties,
 			String namespace );
 }

--- a/core/ingest/src/main/java/mil/nga/giat/geowave/core/ingest/hdfs/mapreduce/AbstractMapReduceIngest.java
+++ b/core/ingest/src/main/java/mil/nga/giat/geowave/core/ingest/hdfs/mapreduce/AbstractMapReduceIngest.java
@@ -27,7 +27,7 @@ import mil.nga.giat.geowave.mapreduce.output.GeoWaveOutputFormat;
 /**
  * This class can be sub-classed to run map-reduce jobs within the ingest
  * framework using plugins provided by types that are discovered through SPI.
- * 
+ *
  * @param <T>
  *            The type of map-reduce ingest plugin that can be persisted to the
  *            map-reduce job configuration and used by the mapper and/or reducer
@@ -142,13 +142,9 @@ abstract public class AbstractMapReduceIngest<T extends Persistable & DataAdapte
 		// set geowave output format
 		job.setOutputFormatClass(GeoWaveOutputFormat.class);
 
-		// set data store info
-		GeoWaveOutputFormat.setDataStoreName(
+		GeoWaveOutputFormat.setStoreOptions(
 				job.getConfiguration(),
-				dataStoreOptions.getFactoryFamily().getDataStoreFactory().getName());
-		GeoWaveOutputFormat.setStoreConfigOptions(
-				job.getConfiguration(),
-				dataStoreOptions.getFactoryOptionsAsMap());
+				dataStoreOptions);
 		final WritableDataAdapter<?>[] dataAdapters = ingestPlugin.getDataAdapters(ingestOptions.getVisibility());
 		for (final WritableDataAdapter<?> dataAdapter : dataAdapters) {
 			GeoWaveOutputFormat.addDataAdapter(

--- a/core/ingest/src/main/java/mil/nga/giat/geowave/core/ingest/operations/ListPluginsCommand.java
+++ b/core/ingest/src/main/java/mil/nga/giat/geowave/core/ingest/operations/ListPluginsCommand.java
@@ -63,7 +63,7 @@ public class ListPluginsCommand extends
 			final StoreFactoryFamilySpi dataStoreFactory = dataStoreFactoryEntry.getValue();
 			final String desc = dataStoreFactory.getDescription() == null ? "no description" : dataStoreFactory
 					.getDescription();
-			final String text = "  " + dataStoreFactory.getName() + ":\n    " + desc;
+			final String text = "  " + dataStoreFactory.getType() + ":\n    " + desc;
 			pw.println(text);
 			pw.println();
 		}

--- a/core/mapreduce/src/main/java/mil/nga/giat/geowave/mapreduce/AbstractGeoWaveJobRunner.java
+++ b/core/mapreduce/src/main/java/mil/nga/giat/geowave/mapreduce/AbstractGeoWaveJobRunner.java
@@ -1,17 +1,17 @@
 package mil.nga.giat.geowave.mapreduce;
 
-import mil.nga.giat.geowave.core.store.operations.remote.options.DataStorePluginOptions;
-import mil.nga.giat.geowave.core.store.query.DistributableQuery;
-import mil.nga.giat.geowave.core.store.query.QueryOptions;
-import mil.nga.giat.geowave.mapreduce.input.GeoWaveInputFormat;
-import mil.nga.giat.geowave.mapreduce.output.GeoWaveOutputFormat;
-
 import org.apache.commons.cli.ParseException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.Configured;
 import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.util.Tool;
 import org.apache.log4j.Logger;
+
+import mil.nga.giat.geowave.core.store.operations.remote.options.DataStorePluginOptions;
+import mil.nga.giat.geowave.core.store.query.DistributableQuery;
+import mil.nga.giat.geowave.core.store.query.QueryOptions;
+import mil.nga.giat.geowave.mapreduce.input.GeoWaveInputFormat;
+import mil.nga.giat.geowave.mapreduce.output.GeoWaveOutputFormat;
 
 /**
  * This class can run a basic job to query GeoWave. It manages datastore
@@ -31,7 +31,7 @@ public abstract class AbstractGeoWaveJobRunner extends
 	protected Integer maxInputSplits = null;
 
 	public AbstractGeoWaveJobRunner(
-			DataStorePluginOptions dataStoreOptions ) {
+			final DataStorePluginOptions dataStoreOptions ) {
 		this.dataStoreOptions = dataStoreOptions;
 	}
 
@@ -45,19 +45,13 @@ public abstract class AbstractGeoWaveJobRunner extends
 		// must use the assembled job configuration
 		final Configuration conf = job.getConfiguration();
 
-		GeoWaveInputFormat.setDataStoreName(
+		GeoWaveInputFormat.setStoreOptions(
 				conf,
-				dataStoreOptions.getType());
-		GeoWaveInputFormat.setStoreConfigOptions(
-				conf,
-				dataStoreOptions.getFactoryOptionsAsMap());
+				dataStoreOptions);
 
-		GeoWaveOutputFormat.setDataStoreName(
+		GeoWaveOutputFormat.setStoreOptions(
 				conf,
-				dataStoreOptions.getType());
-		GeoWaveOutputFormat.setStoreConfigOptions(
-				conf,
-				dataStoreOptions.getFactoryOptionsAsMap());
+				dataStoreOptions);
 
 		job.setJarByClass(this.getClass());
 
@@ -106,7 +100,7 @@ public abstract class AbstractGeoWaveJobRunner extends
 
 	public void setQueryOptions(
 			final QueryOptions options ) {
-		this.queryOptions = options;
+		queryOptions = options;
 	}
 
 	public void setQuery(

--- a/core/mapreduce/src/main/java/mil/nga/giat/geowave/mapreduce/input/GeoWaveInputConfigurator.java
+++ b/core/mapreduce/src/main/java/mil/nga/giat/geowave/mapreduce/input/GeoWaveInputConfigurator.java
@@ -101,7 +101,7 @@ public class GeoWaveInputConfigurator extends
 			final Configuration config ) {
 		final String input = config.get(enumToConfKey(
 				implementingClass,
-				GeoWaveMetaStore.INDEX));
+				GeoWaveConfg.INDEX));
 		if (input != null) {
 			final byte[] indexBytes = ByteArrayUtils.byteArrayFromString(input);
 			return PersistenceUtils.fromBinary(

--- a/core/mapreduce/src/main/java/mil/nga/giat/geowave/mapreduce/output/GeoWaveOutputFormat.java
+++ b/core/mapreduce/src/main/java/mil/nga/giat/geowave/mapreduce/output/GeoWaveOutputFormat.java
@@ -30,6 +30,7 @@ import mil.nga.giat.geowave.core.store.adapter.exceptions.MismatchedIndexToAdapt
 import mil.nga.giat.geowave.core.store.index.Index;
 import mil.nga.giat.geowave.core.store.index.IndexStore;
 import mil.nga.giat.geowave.core.store.index.PrimaryIndex;
+import mil.nga.giat.geowave.core.store.operations.remote.options.DataStorePluginOptions;
 import mil.nga.giat.geowave.mapreduce.GeoWaveConfiguratorBase;
 import mil.nga.giat.geowave.mapreduce.JobContextAdapterStore;
 import mil.nga.giat.geowave.mapreduce.JobContextIndexStore;
@@ -50,7 +51,7 @@ public class GeoWaveOutputFormat extends
 			throws IOException,
 			InterruptedException {
 		try {
-			final Map<String, String> configOptions = getStoreConfigOptions(context);
+			final Map<String, String> configOptions = getStoreOptionsMap(context);
 			final AdapterStore persistentAdapterStore = GeoWaveStoreFinder.createAdapterStore(configOptions);
 			final DataAdapter<?>[] adapters = JobContextAdapterStore.getDataAdapters(context);
 			for (final DataAdapter<?> a : adapters) {
@@ -62,17 +63,17 @@ public class GeoWaveOutputFormat extends
 			final IndexStore persistentIndexStore = GeoWaveStoreFinder.createIndexStore(configOptions);
 			final Index[] indices = JobContextIndexStore.getIndices(context);
 			if (LOGGER.isDebugEnabled()) {
-				StringBuilder sbDebug = new StringBuilder();
+				final StringBuilder sbDebug = new StringBuilder();
 
 				sbDebug.append("Config Options: ");
-				for (Map.Entry<String, String> entry : configOptions.entrySet()) {
+				for (final Map.Entry<String, String> entry : configOptions.entrySet()) {
 					sbDebug.append(entry.getKey() + "/" + entry.getValue() + ", ");
 				}
 				sbDebug.append("\n\tIndices Size: " + indices.length);
 				sbDebug.append("\n\tpersistentIndexStore: " + persistentIndexStore);
 				final String filename = "/META-INF/services/mil.nga.giat.geowave.core.store.StoreFactoryFamilySpi";
 
-				InputStream is = context.getClass().getResourceAsStream(
+				final InputStream is = context.getClass().getResourceAsStream(
 						filename);
 				if (is == null) {
 					sbDebug.append("\n\tStoreFactoryFamilySpi: Unable to open file '" + filename + "'");
@@ -110,19 +111,27 @@ public class GeoWaveOutputFormat extends
 		}
 	}
 
-	public static void setDataStoreName(
+	public static void setStoreOptions(
 			final Configuration config,
-			final String dataStoreName ) {
-		GeoWaveConfiguratorBase.setDataStoreName(
-				CLASS,
-				config,
-				dataStoreName);
+			final DataStorePluginOptions storeOptions ) {
+		if (storeOptions != null) {
+			GeoWaveConfiguratorBase.setStoreOptionsMap(
+					CLASS,
+					config,
+					storeOptions.getOptionsAsMap());
+		}
+		else {
+			GeoWaveConfiguratorBase.setStoreOptionsMap(
+					CLASS,
+					config,
+					null);
+		}
 	}
 
-	public static void setStoreConfigOptions(
+	public static void setStoreOptionsMap(
 			final Configuration config,
 			final Map<String, String> storeConfigOptions ) {
-		GeoWaveConfiguratorBase.setStoreConfigOptions(
+		GeoWaveConfiguratorBase.setStoreOptionsMap(
 				CLASS,
 				config,
 				storeConfigOptions);
@@ -158,16 +167,16 @@ public class GeoWaveOutputFormat extends
 				context);
 	}
 
-	public static Map<String, String> getStoreConfigOptions(
+	public static DataStorePluginOptions getStoreOptions(
 			final JobContext context ) {
-		return GeoWaveConfiguratorBase.getStoreConfigOptions(
+		return GeoWaveConfiguratorBase.getStoreOptions(
 				CLASS,
 				context);
 	}
 
-	public static String getDataStoreName(
+	public static Map<String, String> getStoreOptionsMap(
 			final JobContext context ) {
-		return GeoWaveConfiguratorBase.getDataStoreName(
+		return GeoWaveConfiguratorBase.getStoreOptionsMap(
 				CLASS,
 				context);
 	}
@@ -179,7 +188,7 @@ public class GeoWaveOutputFormat extends
 			InterruptedException {
 		// attempt to get each of the GeoWave stores from the job context
 		try {
-			final Map<String, String> configOptions = getStoreConfigOptions(context);
+			final Map<String, String> configOptions = getStoreOptionsMap(context);
 			if (GeoWaveStoreFinder.createDataStore(configOptions) == null) {
 				final String msg = "Unable to find GeoWave data store";
 				LOGGER.warn(msg);

--- a/core/store/src/main/java/mil/nga/giat/geowave/core/store/GenericFactory.java
+++ b/core/store/src/main/java/mil/nga/giat/geowave/core/store/GenericFactory.java
@@ -2,7 +2,7 @@ package mil.nga.giat.geowave.core.store;
 
 public interface GenericFactory
 {
-	public String getName();
+	public String getType();
 
 	public String getDescription();
 }

--- a/core/store/src/main/java/mil/nga/giat/geowave/core/store/GeoWaveStoreFinder.java
+++ b/core/store/src/main/java/mil/nga/giat/geowave/core/store/GeoWaveStoreFinder.java
@@ -165,7 +165,7 @@ public class GeoWaveStoreFinder
 			ConfigOption[] factoryOptions = ConfigUtils.createConfigOptionsFromJCommander(factory
 					.getDataStoreFactory()
 					.createOptionsInstance());
-			LOGGER.debug("OPTIONS -- length: " + factoryOptions.length + ", " + factory.getName());
+			LOGGER.debug("OPTIONS -- length: " + factoryOptions.length + ", " + factory.getType());
 			if (missingOptions.isEmpty()
 					&& ((matchingFactory == null) || (factoryOptions.length >= matchingFactoryOptionCount))) {
 				matchingFactory = factory;
@@ -179,7 +179,7 @@ public class GeoWaveStoreFinder
 		}
 		else if (matchingFactoriesHaveSameOptionCount) {
 			LOGGER.warn("Multiple valid stores found with equal specificity for store");
-			LOGGER.warn(matchingFactory.getName() + " will be automatically chosen");
+			LOGGER.warn(matchingFactory.getType() + " will be automatically chosen");
 		}
 		return matchingFactory;
 	}
@@ -239,7 +239,7 @@ public class GeoWaveStoreFinder
 			while (storeFactories.hasNext()) {
 				final T storeFactory = storeFactories.next();
 				if (storeFactory != null) {
-					final String name = storeFactory.getName();
+					final String name = storeFactory.getType();
 					registeredFactories.put(
 							ConfigUtils.cleanOptionName(name),
 							storeFactory);

--- a/core/store/src/main/java/mil/nga/giat/geowave/core/store/StoreFactoryOptions.java
+++ b/core/store/src/main/java/mil/nga/giat/geowave/core/store/StoreFactoryOptions.java
@@ -2,11 +2,13 @@ package mil.nga.giat.geowave.core.store;
 
 import com.beust.jcommander.Parameter;
 
+import mil.nga.giat.geowave.core.store.operations.remote.options.DataStorePluginOptions;
+
 /**
  * This interface doesn't actually do anything, is just used for tracking during
  * development.
  */
-public class StoreFactoryOptions
+abstract public class StoreFactoryOptions
 {
 
 	public final static String GEOWAVE_NAMESPACE_OPTION = "gwNamespace";
@@ -19,8 +21,14 @@ public class StoreFactoryOptions
 	}
 
 	public void setGeowaveNamespace(
-			String geowaveNamespace ) {
+			final String geowaveNamespace ) {
 		this.geowaveNamespace = geowaveNamespace;
 	}
 
+	public abstract StoreFactoryFamilySpi getStoreFactory();
+
+	public DataStorePluginOptions createPluginOptions() {
+		return new DataStorePluginOptions(
+				this);
+	}
 }

--- a/core/store/src/main/java/mil/nga/giat/geowave/core/store/config/ConfigUtils.java
+++ b/core/store/src/main/java/mil/nga/giat/geowave/core/store/config/ConfigUtils.java
@@ -11,6 +11,8 @@ import mil.nga.giat.geowave.core.cli.prefix.JCommanderPrefixTranslator;
 import mil.nga.giat.geowave.core.cli.prefix.JCommanderPropertiesTransformer;
 import mil.nga.giat.geowave.core.cli.prefix.JCommanderTranslationMap;
 import mil.nga.giat.geowave.core.cli.prefix.TranslationEntry;
+import mil.nga.giat.geowave.core.store.GeoWaveStoreFinder;
+import mil.nga.giat.geowave.core.store.StoreFactoryOptions;
 
 public class ConfigUtils
 {
@@ -58,17 +60,17 @@ public class ConfigUtils
 	 * create/populate an AbstractConfigOptions map.
 	 */
 	public static ConfigOption[] createConfigOptionsFromJCommander(
-			Object createOptionsInstance ) {
+			final Object createOptionsInstance ) {
 		ConfigOption[] opts = null;
 		if (createOptionsInstance != null) {
-			JCommanderPrefixTranslator translator = new JCommanderPrefixTranslator();
+			final JCommanderPrefixTranslator translator = new JCommanderPrefixTranslator();
 			translator.addObject(createOptionsInstance);
-			JCommanderTranslationMap map = translator.translate();
-			Collection<TranslationEntry> entries = map.getEntries().values();
+			final JCommanderTranslationMap map = translator.translate();
+			final Collection<TranslationEntry> entries = map.getEntries().values();
 			final List<ConfigOption> options = new ArrayList<ConfigOption>();
-			for (TranslationEntry entry : entries) {
+			for (final TranslationEntry entry : entries) {
 				if (!entry.isHidden()) {
-					ConfigOption opt = new ConfigOption(
+					final ConfigOption opt = new ConfigOption(
 							entry.getAsPropertyName(),
 							entry.getDescription(),
 							!entry.isRequired(),
@@ -89,11 +91,11 @@ public class ConfigUtils
 	 * Take the given options and populate the given options list. This is
 	 * JCommander specific.
 	 */
-	public static <T> T populateOptionsFromList(
-			T optionsObject,
-			Map<String, String> optionList ) {
+	public static <T extends StoreFactoryOptions> T populateOptionsFromList(
+			final T optionsObject,
+			final Map<String, String> optionList ) {
 		if (optionsObject != null) {
-			JCommanderPropertiesTransformer translator = new JCommanderPropertiesTransformer();
+			final JCommanderPropertiesTransformer translator = new JCommanderPropertiesTransformer();
 			translator.addObject(optionsObject);
 			translator.transformFromMap(optionList);
 		}
@@ -105,12 +107,15 @@ public class ConfigUtils
 	 * JCommander specific.
 	 */
 	public static Map<String, String> populateListFromOptions(
-			Object optionsObject ) {
-		Map<String, String> mapOptions = new HashMap<String, String>();
+			final StoreFactoryOptions optionsObject ) {
+		final Map<String, String> mapOptions = new HashMap<String, String>();
 		if (optionsObject != null) {
-			JCommanderPropertiesTransformer translator = new JCommanderPropertiesTransformer();
+			final JCommanderPropertiesTransformer translator = new JCommanderPropertiesTransformer();
 			translator.addObject(optionsObject);
 			translator.transformToMap(mapOptions);
+			mapOptions.put(
+					GeoWaveStoreFinder.STORE_HINT_KEY,
+					optionsObject.getStoreFactory().getType());
 		}
 		return mapOptions;
 	}

--- a/core/store/src/main/java/mil/nga/giat/geowave/core/store/memory/AbstractMemoryFactory.java
+++ b/core/store/src/main/java/mil/nga/giat/geowave/core/store/memory/AbstractMemoryFactory.java
@@ -7,7 +7,7 @@ abstract public class AbstractMemoryFactory implements
 		GenericFactory
 {
 	@Override
-	public String getName() {
+	public String getType() {
 		return "memory";
 	}
 

--- a/core/store/src/main/java/mil/nga/giat/geowave/core/store/memory/MemoryRequiredOptions.java
+++ b/core/store/src/main/java/mil/nga/giat/geowave/core/store/memory/MemoryRequiredOptions.java
@@ -1,5 +1,6 @@
 package mil.nga.giat.geowave.core.store.memory;
 
+import mil.nga.giat.geowave.core.store.StoreFactoryFamilySpi;
 import mil.nga.giat.geowave.core.store.StoreFactoryOptions;
 
 /**
@@ -8,4 +9,9 @@ import mil.nga.giat.geowave.core.store.StoreFactoryOptions;
 public class MemoryRequiredOptions extends
 		StoreFactoryOptions
 {
+
+	@Override
+	public StoreFactoryFamilySpi getStoreFactory() {
+		return new MemoryStoreFactoryFamily();
+	}
 }

--- a/extensions/adapters/raster/src/main/java/mil/nga/giat/geowave/adapter/raster/resize/RasterTileResizeJobRunner.java
+++ b/extensions/adapters/raster/src/main/java/mil/nga/giat/geowave/adapter/raster/resize/RasterTileResizeJobRunner.java
@@ -22,7 +22,6 @@ import mil.nga.giat.geowave.core.store.CloseableIterator;
 import mil.nga.giat.geowave.core.store.DataStore;
 import mil.nga.giat.geowave.core.store.IndexWriter;
 import mil.nga.giat.geowave.core.store.adapter.DataAdapter;
-import mil.nga.giat.geowave.core.store.config.ConfigUtils;
 import mil.nga.giat.geowave.core.store.index.Index;
 import mil.nga.giat.geowave.core.store.index.IndexStore;
 import mil.nga.giat.geowave.core.store.index.PrimaryIndex;
@@ -104,12 +103,9 @@ public class RasterTileResizeJobRunner extends
 				job.getConfiguration(),
 				rasterResizeOptions.getMaxSplits());
 
-		GeoWaveInputFormat.setDataStoreName(
+		GeoWaveInputFormat.setStoreOptions(
 				job.getConfiguration(),
-				inputStoreOptions.getFactoryFamily().getDataStoreFactory().getName());
-		GeoWaveInputFormat.setStoreConfigOptions(
-				job.getConfiguration(),
-				inputStoreOptions.getFactoryOptionsAsMap());
+				inputStoreOptions);
 
 		final DataAdapter adapter = inputStoreOptions.createAdapterStore().getAdapter(
 				new ByteArrayId(
@@ -145,12 +141,9 @@ public class RasterTileResizeJobRunner extends
 						"Index does not exist in namespace '" + inputStoreOptions.getGeowaveNamespace() + "'");
 			}
 		}
-		GeoWaveOutputFormat.setDataStoreName(
+		GeoWaveOutputFormat.setStoreOptions(
 				job.getConfiguration(),
-				outputStoreOptions.getFactoryFamily().getDataStoreFactory().getName());
-		GeoWaveOutputFormat.setStoreConfigOptions(
-				job.getConfiguration(),
-				ConfigUtils.populateListFromOptions(outputStoreOptions.getFactoryOptions()));
+				outputStoreOptions);
 		GeoWaveOutputFormat.addIndex(
 				job.getConfiguration(),
 				index);

--- a/extensions/adapters/vector/src/main/java/mil/nga/giat/geowave/adapter/vector/export/VectorMRExportJobRunner.java
+++ b/extensions/adapters/vector/src/main/java/mil/nga/giat/geowave/adapter/vector/export/VectorMRExportJobRunner.java
@@ -28,7 +28,6 @@ import mil.nga.giat.geowave.core.cli.operations.config.options.ConfigOptions;
 import mil.nga.giat.geowave.core.cli.parser.CommandLineOperationParams;
 import mil.nga.giat.geowave.core.cli.parser.OperationParser;
 import mil.nga.giat.geowave.core.index.ByteArrayId;
-import mil.nga.giat.geowave.core.store.CloseableIterator;
 import mil.nga.giat.geowave.core.store.adapter.AdapterStore;
 import mil.nga.giat.geowave.core.store.adapter.DataAdapter;
 import mil.nga.giat.geowave.core.store.index.Index;
@@ -37,7 +36,6 @@ import mil.nga.giat.geowave.core.store.operations.remote.options.DataStorePlugin
 import mil.nga.giat.geowave.core.store.query.DistributableQuery;
 import mil.nga.giat.geowave.core.store.query.QueryOptions;
 import mil.nga.giat.geowave.mapreduce.GeoWaveConfiguratorBase;
-import mil.nga.giat.geowave.mapreduce.JobContextAdapterStore;
 import mil.nga.giat.geowave.mapreduce.input.GeoWaveInputFormat;
 
 public class VectorMRExportJobRunner extends
@@ -53,10 +51,10 @@ public class VectorMRExportJobRunner extends
 	private final String hdfsPath;
 
 	public VectorMRExportJobRunner(
-			DataStorePluginOptions storeOptions,
-			VectorMRExportOptions mrOptions,
-			String hdfsHostPort,
-			String hdfsPath ) {
+			final DataStorePluginOptions storeOptions,
+			final VectorMRExportOptions mrOptions,
+			final String hdfsHostPort,
+			final String hdfsPath ) {
 		this.storeOptions = storeOptions;
 		this.mrOptions = mrOptions;
 		this.hdfsHostPort = hdfsHostPort;
@@ -91,7 +89,7 @@ public class VectorMRExportJobRunner extends
 						@Override
 						public DataAdapter<?> apply(
 								final String input ) {
-							return (DataAdapter<?>) adapterStore.getAdapter(new ByteArrayId(
+							return adapterStore.getAdapter(new ByteArrayId(
 									input));
 						}
 					}));
@@ -146,12 +144,9 @@ public class VectorMRExportJobRunner extends
 							options.getIndex(),
 							null));
 		}
-		GeoWaveInputFormat.setDataStoreName(
+		GeoWaveInputFormat.setStoreOptions(
 				conf,
-				storeOptions.getType());
-		GeoWaveInputFormat.setStoreConfigOptions(
-				conf,
-				storeOptions.getFactoryOptionsAsMap());
+				storeOptions);
 		// the above code is a temporary placeholder until this gets merged with
 		// the new commandline options
 		GeoWaveInputFormat.setQueryOptions(
@@ -207,11 +202,11 @@ public class VectorMRExportJobRunner extends
 	public static void main(
 			final String[] args )
 			throws Exception {
-		ConfigOptions opts = new ConfigOptions();
-		OperationParser parser = new OperationParser();
+		final ConfigOptions opts = new ConfigOptions();
+		final OperationParser parser = new OperationParser();
 		parser.addAdditionalObject(opts);
-		VectorMRExportCommand command = new VectorMRExportCommand();
-		CommandLineOperationParams params = parser.parse(
+		final VectorMRExportCommand command = new VectorMRExportCommand();
+		final CommandLineOperationParams params = parser.parse(
 				command,
 				args);
 		opts.prepare(params);

--- a/extensions/adapters/vector/src/main/java/mil/nga/giat/geowave/adapter/vector/plugin/GeoWaveGTDataStoreFactory.java
+++ b/extensions/adapters/vector/src/main/java/mil/nga/giat/geowave/adapter/vector/plugin/GeoWaveGTDataStoreFactory.java
@@ -32,7 +32,7 @@ import mil.nga.giat.geowave.core.store.config.ConfigOption;
  * GeoWave as a DataStore to GeoTools. It should be defined within a file
  * META-INF/services/org.geotools.data.DataStoreFactorySpi to inject this into
  * GeoTools.
- * 
+ *
  */
 public class GeoWaveGTDataStoreFactory implements
 		DataStoreFactorySpi
@@ -73,19 +73,20 @@ public class GeoWaveGTDataStoreFactory implements
 			if (argumentSupersetStores == null) {
 				// initialize arguments map
 				argumentSupersetStores = new HashMap<String, Set<StoreFactoryFamilySpi>>();
-				for (StoreFactoryFamilySpi factory : dataStoreFactories) {
-					for (StoreFactoryFamilySpi otherFactory : dataStoreFactories) {
+				for (final StoreFactoryFamilySpi factory : dataStoreFactories) {
+					for (final StoreFactoryFamilySpi otherFactory : dataStoreFactories) {
 						if (factory != otherFactory) {
 							// if otherFactory arguments are superset of
 							// factory arguments
-							ConfigOption[] requiredOptions = GeoWaveStoreFinder.getRequiredOptions(factory);
-							ConfigOption[] otherRequiredOptions = GeoWaveStoreFinder.getRequiredOptions(otherFactory);
+							final ConfigOption[] requiredOptions = GeoWaveStoreFinder.getRequiredOptions(factory);
+							final ConfigOption[] otherRequiredOptions = GeoWaveStoreFinder
+									.getRequiredOptions(otherFactory);
 							boolean superSet = false;
 							if (otherRequiredOptions.length > requiredOptions.length) {
 								superSet = true;
-								for (ConfigOption requiredOption : requiredOptions) {
+								for (final ConfigOption requiredOption : requiredOptions) {
 									boolean foundInOtherOptions = false;
-									for (ConfigOption otherOption : otherRequiredOptions) {
+									for (final ConfigOption otherOption : otherRequiredOptions) {
 										if (otherOption.getName().equals(
 												requiredOption.getName())) {
 											foundInOtherOptions = true;
@@ -102,11 +103,11 @@ public class GeoWaveGTDataStoreFactory implements
 							if (superSet) {
 								// add otherfactory to factory's map entry
 								Set<StoreFactoryFamilySpi> supersetStores = argumentSupersetStores.get(factory
-										.getName());
+										.getType());
 								if (supersetStores == null) {
 									supersetStores = new HashSet<StoreFactoryFamilySpi>();
 									argumentSupersetStores.put(
-											factory.getName(),
+											factory.getType(),
 											supersetStores);
 								}
 								supersetStores.add(otherFactory);
@@ -201,13 +202,13 @@ public class GeoWaveGTDataStoreFactory implements
 
 	@Override
 	public String getDisplayName() {
-		return DISPLAY_NAME_PREFIX + geowaveStoreFactoryFamily.getName();
+		return DISPLAY_NAME_PREFIX + geowaveStoreFactoryFamily.getType().toUpperCase();
 	}
 
 	@Override
 	public String getDescription() {
 		return "A datastore that uses the GeoWave API for spatial data persistence in "
-				+ geowaveStoreFactoryFamily.getName() + ". " + geowaveStoreFactoryFamily.getDescription();
+				+ geowaveStoreFactoryFamily.getType() + ". " + geowaveStoreFactoryFamily.getDescription();
 	}
 
 	@Override
@@ -225,9 +226,9 @@ public class GeoWaveGTDataStoreFactory implements
 					geowaveStoreFactoryFamily,
 					params);
 
-			if (argumentSupersetStores.containsKey(geowaveStoreFactoryFamily.getName())) {
-				for (StoreFactoryFamilySpi supersetStore : argumentSupersetStores.get(geowaveStoreFactoryFamily
-						.getName())) {
+			if (argumentSupersetStores.containsKey(geowaveStoreFactoryFamily.getType())) {
+				for (final StoreFactoryFamilySpi supersetStore : argumentSupersetStores.get(geowaveStoreFactoryFamily
+						.getType())) {
 					// if we have can construct a superset store with these
 					// args, don't process with this factory
 					try {
@@ -332,8 +333,8 @@ public class GeoWaveGTDataStoreFactory implements
 	 * re-use instances of the same class, so each individual geowave data store
 	 * must be registered as a different class (the alternative is dynamic
 	 * compilation of classes to add to the classloader).
-	 * 
-	 * 
+	 *
+	 *
 	 */
 	private static class GeoWaveStoreToGeoToolsDataStore implements
 			Function<StoreFactoryFamilySpi, DataStoreFactorySpi>

--- a/extensions/cli/geoserver/src/main/java/mil/nga/giat/geowave/cli/geoserver/GeoServerRestClient.java
+++ b/extensions/cli/geoserver/src/main/java/mil/nga/giat/geowave/cli/geoserver/GeoServerRestClient.java
@@ -28,6 +28,14 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.glassfish.jersey.client.authentication.HttpAuthenticationFeature;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+import com.beust.jcommander.ParameterException;
+
 import mil.nga.giat.geowave.adapter.raster.adapter.RasterDataAdapter;
 import mil.nga.giat.geowave.adapter.vector.GeotoolsFeatureDataAdapter;
 import mil.nga.giat.geowave.cli.geoserver.GeoServerAddLayerCommand.AddOption;
@@ -38,14 +46,6 @@ import mil.nga.giat.geowave.core.store.operations.remote.options.DataStorePlugin
 import mil.nga.giat.geowave.core.store.operations.remote.options.StoreLoader;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
-
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
-import org.glassfish.jersey.client.authentication.HttpAuthenticationFeature;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-
-import com.beust.jcommander.ParameterException;
 
 public class GeoServerRestClient
 {
@@ -58,17 +58,17 @@ public class GeoServerRestClient
 		Boolean isRaster;
 	}
 
-	private GeoServerConfig config;
+	private final GeoServerConfig config;
 	private WebTarget webTarget = null;
 
 	public GeoServerRestClient(
-			GeoServerConfig config ) {
+			final GeoServerConfig config ) {
 		this.config = config;
 		LOGGER.setLevel(Level.DEBUG);
 	}
 
 	/**
-	 * 
+	 *
 	 * @return
 	 */
 	public GeoServerConfig getConfig() {
@@ -90,7 +90,7 @@ public class GeoServerRestClient
 
 	/**
 	 * Convenience - add layer(s) for the given store to geoserver
-	 * 
+	 *
 	 * @param workspaceName
 	 * @param storeName
 	 * @param adapterId
@@ -98,22 +98,22 @@ public class GeoServerRestClient
 	 * @return
 	 */
 	public Response addLayer(
-			String workspaceName,
+			final String workspaceName,
 			final String storeName,
 			final String adapterId,
 			final String defaultStyle ) {
 		// retrieve the adapter info list for the store
-		ArrayList<DataAdapterInfo> adapterInfoList = getStoreAdapterInfo(
+		final ArrayList<DataAdapterInfo> adapterInfoList = getStoreAdapterInfo(
 				storeName,
 				adapterId);
 
 		LOGGER.debug("Finished retrieving adapter list");
 
-		if (adapterInfoList.size() > 1 && adapterId == null) {
+		if ((adapterInfoList.size() > 1) && (adapterId == null)) {
 			LOGGER.debug("addlayer doesn't know how to deal with multiple adapters");
 
-			String descr = "Please use -a, or choose one of these with -id:";
-			JSONObject jsonObj = getJsonFromAdapters(
+			final String descr = "Please use -a, or choose one of these with -id:";
+			final JSONObject jsonObj = getJsonFromAdapters(
 					adapterInfoList,
 					descr);
 
@@ -127,25 +127,25 @@ public class GeoServerRestClient
 		if (!workspaceExists(workspaceName)) {
 			LOGGER.debug("addlayer needs to create the " + workspaceName + " workspace");
 
-			Response addWsResponse = addWorkspace(workspaceName);
+			final Response addWsResponse = addWorkspace(workspaceName);
 			if (addWsResponse.getStatus() != Status.CREATED.getStatusCode()) {
 				return addWsResponse;
 			}
 		}
 
-		String cvgStoreName = storeName + GeoServerConfig.DEFAULT_CS;
-		String dataStoreName = storeName + GeoServerConfig.DEFAULT_DS;
+		final String cvgStoreName = storeName + GeoServerConfig.DEFAULT_CS;
+		final String dataStoreName = storeName + GeoServerConfig.DEFAULT_DS;
 
 		// iterate through data adapters
-		for (DataAdapterInfo dataAdapterInfo : adapterInfoList) {
+		for (final DataAdapterInfo dataAdapterInfo : adapterInfoList) {
 			// handle coverage stores & coverages
 			if (dataAdapterInfo.isRaster) {
 				// verify coverage store exists
-				Response getCsResponse = getCoverageStore(
+				final Response getCsResponse = getCoverageStore(
 						workspaceName,
 						cvgStoreName);
 				if (getCsResponse.getStatus() == Status.NOT_FOUND.getStatusCode()) {
-					Response addCsResponse = addCoverageStore(
+					final Response addCsResponse = addCoverageStore(
 							workspaceName,
 							cvgStoreName,
 							storeName,
@@ -162,7 +162,7 @@ public class GeoServerRestClient
 				}
 
 				// See if the coverage already exists
-				Response getCvResponse = getCoverage(
+				final Response getCvResponse = getCoverage(
 						workspaceName,
 						cvgStoreName,
 						dataAdapterInfo.adapterId);
@@ -172,7 +172,7 @@ public class GeoServerRestClient
 				}
 
 				// We have a coverage store. Add the layer per the adapter ID
-				Response addCvResponse = addCoverage(
+				final Response addCvResponse = addCoverage(
 						workspaceName,
 						cvgStoreName,
 						dataAdapterInfo.adapterId);
@@ -183,11 +183,11 @@ public class GeoServerRestClient
 			// handle datastores and feature layers
 			else {
 				// verify datastore exists
-				Response getDsResponse = getDatastore(
+				final Response getDsResponse = getDatastore(
 						workspaceName,
 						dataStoreName);
 				if (getDsResponse.getStatus() == Status.NOT_FOUND.getStatusCode()) {
-					Response addDsResponse = addDatastore(
+					final Response addDsResponse = addDatastore(
 							workspaceName,
 							dataStoreName,
 							storeName);
@@ -202,7 +202,7 @@ public class GeoServerRestClient
 				LOGGER.debug("Checking for existing feature layer: " + dataAdapterInfo.adapterId);
 
 				// See if the feature layer already exists
-				Response getFlResponse = getFeatureLayer(dataAdapterInfo.adapterId);
+				final Response getFlResponse = getFeatureLayer(dataAdapterInfo.adapterId);
 				if (getFlResponse.getStatus() == Status.OK.getStatusCode()) {
 					LOGGER.debug(dataAdapterInfo.adapterId + " layer already exists");
 					continue;
@@ -212,7 +212,7 @@ public class GeoServerRestClient
 						+ getFlResponse.getStatus());
 
 				// We have a datastore. Add the layer per the adapter ID
-				Response addFlResponse = addFeatureLayer(
+				final Response addFlResponse = addFeatureLayer(
 						workspaceName,
 						dataStoreName,
 						dataAdapterInfo.adapterId,
@@ -225,7 +225,7 @@ public class GeoServerRestClient
 
 		// Report back to the caller the adapter IDs and the types that were
 		// used to create the layers
-		JSONObject jsonObj = getJsonFromAdapters(
+		final JSONObject jsonObj = getJsonFromAdapters(
 				adapterInfoList,
 				"Successfully added:");
 
@@ -235,27 +235,27 @@ public class GeoServerRestClient
 
 	/**
 	 * Get JSON object(s) from adapter list
-	 * 
+	 *
 	 * @param adapterInfoList
 	 * @param description
 	 * @return JSONObject
 	 */
 	private JSONObject getJsonFromAdapters(
-			ArrayList<DataAdapterInfo> adapterInfoList,
-			String description ) {
-		StringBuffer buf = new StringBuffer();
+			final ArrayList<DataAdapterInfo> adapterInfoList,
+			final String description ) {
+		final StringBuffer buf = new StringBuffer();
 
 		// If we made it this far, let's just iterate through the adapter IDs
 		// and build the JSON response data
 		buf.append("{'description':'" + description + "', " + "'layers':[");
 
 		for (int i = 0; i < adapterInfoList.size(); i++) {
-			DataAdapterInfo info = adapterInfoList.get(i);
+			final DataAdapterInfo info = adapterInfoList.get(i);
 
 			buf.append("{'id':'" + info.adapterId + "',");
 			buf.append("'type':'" + (info.isRaster ? "raster" : "vector") + "'}");
 
-			if (i < adapterInfoList.size() - 1) {
+			if (i < (adapterInfoList.size() - 1)) {
 				buf.append(",");
 			}
 		}
@@ -267,7 +267,7 @@ public class GeoServerRestClient
 
 	/**
 	 * Check if workspace exists
-	 * 
+	 *
 	 * @param workspace
 	 * @return true if workspace exists, false if not
 	 */
@@ -277,14 +277,14 @@ public class GeoServerRestClient
 			workspace = config.getWorkspace();
 		}
 
-		Response getWsResponse = getWorkspaces();
+		final Response getWsResponse = getWorkspaces();
 		if (getWsResponse.getStatus() == Status.OK.getStatusCode()) {
-			JSONObject jsonResponse = JSONObject.fromObject(getWsResponse.getEntity());
+			final JSONObject jsonResponse = JSONObject.fromObject(getWsResponse.getEntity());
 
 			final JSONArray workspaces = jsonResponse.getJSONArray("workspaces");
 
 			for (int i = 0; i < workspaces.size(); i++) {
-				String wsName = workspaces.getJSONObject(
+				final String wsName = workspaces.getJSONObject(
 						i).getString(
 						"name");
 
@@ -302,7 +302,7 @@ public class GeoServerRestClient
 
 	/**
 	 * Get list of workspaces from geoserver
-	 * 
+	 *
 	 * @return
 	 */
 	public Response getWorkspaces() {
@@ -332,7 +332,7 @@ public class GeoServerRestClient
 
 	/**
 	 * Add workspace to geoserver
-	 * 
+	 *
 	 * @param workspace
 	 * @return
 	 */
@@ -347,7 +347,7 @@ public class GeoServerRestClient
 
 	/**
 	 * Delete workspace from geoserver
-	 * 
+	 *
 	 * @param workspace
 	 * @return
 	 */
@@ -361,21 +361,21 @@ public class GeoServerRestClient
 
 	/**
 	 * Get the string version of a datastore JSONObject from geoserver
-	 * 
+	 *
 	 * @param workspaceName
 	 * @param datastoreName
 	 * @return
 	 */
 	public Response getDatastore(
 			final String workspaceName,
-			String datastoreName ) {
+			final String datastoreName ) {
 		final Response resp = getWebTarget().path(
 				"rest/workspaces/" + workspaceName + "/datastores/" + datastoreName + ".json").request().get();
 
 		if (resp.getStatus() == Status.OK.getStatusCode()) {
 			resp.bufferEntity();
 
-			JSONObject datastore = JSONObject.fromObject(resp.readEntity(String.class));
+			final JSONObject datastore = JSONObject.fromObject(resp.readEntity(String.class));
 
 			if (datastore != null) {
 				return Response.ok(
@@ -388,12 +388,12 @@ public class GeoServerRestClient
 
 	/**
 	 * Get list of Datastore names from geoserver
-	 * 
+	 *
 	 * @param workspaceName
 	 * @return
 	 */
 	public Response getDatastores(
-			String workspaceName ) {
+			final String workspaceName ) {
 		final Response resp = getWebTarget().path(
 				"rest/workspaces/" + workspaceName + "/datastores.json").request().get();
 
@@ -420,30 +420,30 @@ public class GeoServerRestClient
 
 	/**
 	 * Add a geowave datastore to geoserver
-	 * 
+	 *
 	 * @param workspaceName
 	 * @param datastoreName
 	 * @param gwStoreName
 	 * @return
 	 */
 	public Response addDatastore(
-			String workspaceName,
+			final String workspaceName,
 			String datastoreName,
-			String gwStoreName ) {
-		DataStorePluginOptions inputStoreOptions = getStorePlugin(gwStoreName);
+			final String gwStoreName ) {
+		final DataStorePluginOptions inputStoreOptions = getStorePlugin(gwStoreName);
 
-		if (datastoreName == null || datastoreName.isEmpty()) {
+		if ((datastoreName == null) || datastoreName.isEmpty()) {
 			datastoreName = gwStoreName + GeoServerConfig.DEFAULT_DS;
 		}
 
-		String lockMgmt = "memory";
-		String authMgmtPrvdr = "empty";
-		String authDataUrl = "";
-		String queryIndexStrategy = "Best Match";
+		final String lockMgmt = "memory";
+		final String authMgmtPrvdr = "empty";
+		final String authDataUrl = "";
+		final String queryIndexStrategy = "Best Match";
 
 		final String dataStoreJson = createDatastoreJson(
 				inputStoreOptions.getType(),
-				inputStoreOptions.getFactoryOptionsAsMap(),
+				inputStoreOptions.getOptionsAsMap(),
 				datastoreName,
 				lockMgmt,
 				authMgmtPrvdr,
@@ -461,14 +461,14 @@ public class GeoServerRestClient
 
 	/**
 	 * Delete a geowave datastore from geoserver
-	 * 
+	 *
 	 * @param workspaceName
 	 * @param datastoreName
 	 * @return
 	 */
 	public Response deleteDatastore(
-			String workspaceName,
-			String datastoreName ) {
+			final String workspaceName,
+			final String datastoreName ) {
 		return getWebTarget().path(
 				"rest/workspaces/" + workspaceName + "/datastores/" + datastoreName).queryParam(
 				"recurse",
@@ -477,7 +477,7 @@ public class GeoServerRestClient
 
 	/**
 	 * Get a layer from geoserver
-	 * 
+	 *
 	 * @param layerName
 	 * @return
 	 */
@@ -487,7 +487,7 @@ public class GeoServerRestClient
 				"rest/layers/" + layerName + ".json").request().get();
 
 		if (resp.getStatus() == Status.OK.getStatusCode()) {
-			JSONObject layer = JSONObject.fromObject(resp.readEntity(String.class));
+			final JSONObject layer = JSONObject.fromObject(resp.readEntity(String.class));
 
 			if (layer != null) {
 				return Response.ok(
@@ -500,7 +500,7 @@ public class GeoServerRestClient
 
 	/**
 	 * Get list of layers from geoserver
-	 * 
+	 *
 	 * @param workspaceName
 	 *            : if null, don't filter on workspace
 	 * @param datastoreName
@@ -510,11 +510,11 @@ public class GeoServerRestClient
 	 * @return
 	 */
 	public Response getFeatureLayers(
-			String workspaceName,
-			String datastoreName,
-			boolean geowaveOnly ) {
-		boolean wsFilter = (workspaceName != null && !workspaceName.isEmpty());
-		boolean dsFilter = (datastoreName != null && !datastoreName.isEmpty());
+			final String workspaceName,
+			final String datastoreName,
+			final boolean geowaveOnly ) {
+		final boolean wsFilter = ((workspaceName != null) && !workspaceName.isEmpty());
+		final boolean dsFilter = ((datastoreName != null) && !datastoreName.isEmpty());
 
 		final Response resp = getWebTarget().path(
 				"rest/layers.json").request().get();
@@ -534,11 +534,11 @@ public class GeoServerRestClient
 			final Map<String, List<String>> namespaceLayersMap = new HashMap<String, List<String>>();
 			final Pattern p = Pattern.compile("workspaces/(.*?)/datastores/(.*?)/");
 			for (int i = 0; i < layerArray.size(); i++) {
-				boolean include = !geowaveOnly && !wsFilter && !dsFilter; // no
-																			// filtering
-																			// of
-																			// any
-																			// kind
+				final boolean include = !geowaveOnly && !wsFilter && !dsFilter; // no
+				// filtering
+				// of
+				// any
+				// kind
 
 				if (include) { // just grab it...
 					layerInfoArray.add(layerArray.getJSONObject(i));
@@ -566,10 +566,10 @@ public class GeoServerRestClient
 				}
 
 				// filter on datastore?
-				if (!dsFilter || (ds != null && ds.equals(datastoreName))) {
+				if (!dsFilter || ((ds != null) && ds.equals(datastoreName))) {
 
 					// filter on workspace?
-					if (!wsFilter || (ws != null && ws.equals(workspaceName))) {
+					if (!wsFilter || ((ws != null) && ws.equals(workspaceName))) {
 						final JSONObject datastore = JSONObject.fromObject(
 								getDatastore(
 										ds,
@@ -578,7 +578,7 @@ public class GeoServerRestClient
 
 						// only process GeoWave layers
 						if (geowaveOnly) {
-							if (datastore != null && datastore.containsKey("type") && datastore.getString(
+							if ((datastore != null) && datastore.containsKey("type") && datastore.getString(
 									"type").startsWith(
 									"GeoWave Datastore")) {
 
@@ -683,7 +683,7 @@ public class GeoServerRestClient
 
 	/**
 	 * Add feature layer to geoserver
-	 * 
+	 *
 	 * @param workspaceName
 	 * @param datastoreName
 	 * @param layerName
@@ -712,7 +712,7 @@ public class GeoServerRestClient
 
 	/**
 	 * Delete a feature layer from geoserver
-	 * 
+	 *
 	 * @param layerName
 	 * @return
 	 */
@@ -724,7 +724,7 @@ public class GeoServerRestClient
 
 	/**
 	 * Change the default style of a layer
-	 * 
+	 *
 	 * @param layerName
 	 * @param styleName
 	 * @return
@@ -742,7 +742,7 @@ public class GeoServerRestClient
 
 	/**
 	 * Get a geoserver style
-	 * 
+	 *
 	 * @param styleName
 	 * @return
 	 */
@@ -768,7 +768,7 @@ public class GeoServerRestClient
 
 	/**
 	 * Get a list of geoserver styles
-	 * 
+	 *
 	 * @return
 	 */
 	public Response getStyles() {
@@ -799,7 +799,7 @@ public class GeoServerRestClient
 
 	/**
 	 * Add a style to geoserver
-	 * 
+	 *
 	 * @param styleName
 	 * @param fileInStream
 	 * @return
@@ -823,7 +823,7 @@ public class GeoServerRestClient
 
 	/**
 	 * Delete a style from geoserver
-	 * 
+	 *
 	 * @param styleName
 	 * @return
 	 */
@@ -836,21 +836,21 @@ public class GeoServerRestClient
 
 	/**
 	 * Get coverage store from geoserver
-	 * 
+	 *
 	 * @param workspaceName
 	 * @param coverageName
 	 * @return
 	 */
 	public Response getCoverageStore(
 			final String workspaceName,
-			String coverageName ) {
+			final String coverageName ) {
 		final Response resp = getWebTarget().path(
 				"rest/workspaces/" + workspaceName + "/coveragestores/" + coverageName + ".json").request().get();
 
 		if (resp.getStatus() == Status.OK.getStatusCode()) {
 			resp.bufferEntity();
 
-			JSONObject cvgstore = JSONObject.fromObject(resp.readEntity(String.class));
+			final JSONObject cvgstore = JSONObject.fromObject(resp.readEntity(String.class));
 
 			if (cvgstore != null) {
 				return Response.ok(
@@ -863,12 +863,12 @@ public class GeoServerRestClient
 
 	/**
 	 * Get a list of coverage stores from geoserver
-	 * 
+	 *
 	 * @param workspaceName
 	 * @return
 	 */
 	public Response getCoverageStores(
-			String workspaceName ) {
+			final String workspaceName ) {
 		final Response resp = getWebTarget().path(
 				"rest/workspaces/" + workspaceName + "/coveragestores.json").request().get();
 
@@ -895,7 +895,7 @@ public class GeoServerRestClient
 
 	/**
 	 * Add coverage store to geoserver
-	 * 
+	 *
 	 * @param workspaceName
 	 * @param cvgStoreName
 	 * @param gwStoreName
@@ -905,20 +905,20 @@ public class GeoServerRestClient
 	 * @return
 	 */
 	public Response addCoverageStore(
-			String workspaceName,
+			final String workspaceName,
 			String cvgStoreName,
-			String gwStoreName,
-			Boolean equalizeHistogramOverride,
-			String interpolationOverride,
-			Boolean scaleTo8Bit ) {
-		DataStorePluginOptions inputStoreOptions = getStorePlugin(gwStoreName);
+			final String gwStoreName,
+			final Boolean equalizeHistogramOverride,
+			final String interpolationOverride,
+			final Boolean scaleTo8Bit ) {
+		final DataStorePluginOptions inputStoreOptions = getStorePlugin(gwStoreName);
 
-		if (cvgStoreName == null || cvgStoreName.isEmpty()) {
+		if ((cvgStoreName == null) || cvgStoreName.isEmpty()) {
 			cvgStoreName = gwStoreName + GeoServerConfig.DEFAULT_CS;
 		}
 
 		// Get the store's db config
-		Map<String, String> storeConfigMap = inputStoreOptions.getFactoryOptionsAsMap();
+		final Map<String, String> storeConfigMap = inputStoreOptions.getOptionsAsMap();
 
 		// Add in geoserver coverage store info
 		storeConfigMap.put(
@@ -951,14 +951,14 @@ public class GeoServerRestClient
 
 	/**
 	 * Delete coverage store form geoserver
-	 * 
+	 *
 	 * @param workspaceName
 	 * @param cvgstoreName
 	 * @return
 	 */
 	public Response deleteCoverageStore(
-			String workspaceName,
-			String cvgstoreName ) {
+			final String workspaceName,
+			final String cvgstoreName ) {
 		return getWebTarget().path(
 				"rest/workspaces/" + workspaceName + "/coveragestores/" + cvgstoreName).queryParam(
 				"recurse",
@@ -967,14 +967,14 @@ public class GeoServerRestClient
 
 	/**
 	 * Get a list of coverages (raster layers) from geoserver
-	 * 
+	 *
 	 * @param workspaceName
 	 * @param cvsstoreName
 	 * @return
 	 */
 	public Response getCoverages(
-			String workspaceName,
-			String cvsstoreName ) {
+			final String workspaceName,
+			final String cvsstoreName ) {
 		final Response resp = getWebTarget()
 				.path(
 						"rest/workspaces/" + workspaceName + "/coveragestores/" + cvsstoreName + "/coverages.json")
@@ -1004,7 +1004,7 @@ public class GeoServerRestClient
 
 	/**
 	 * Get coverage from geoserver
-	 * 
+	 *
 	 * @param workspaceName
 	 * @param cvgStoreName
 	 * @param coverageName
@@ -1012,8 +1012,8 @@ public class GeoServerRestClient
 	 */
 	public Response getCoverage(
 			final String workspaceName,
-			String cvgStoreName,
-			String coverageName ) {
+			final String cvgStoreName,
+			final String coverageName ) {
 		final Response resp = getWebTarget()
 				.path(
 						"rest/workspaces/" + workspaceName + "/coveragestores/" + cvgStoreName + "/coverages/"
@@ -1024,7 +1024,7 @@ public class GeoServerRestClient
 		if (resp.getStatus() == Status.OK.getStatusCode()) {
 			resp.bufferEntity();
 
-			JSONObject cvg = JSONObject.fromObject(resp.readEntity(String.class));
+			final JSONObject cvg = JSONObject.fromObject(resp.readEntity(String.class));
 
 			if (cvg != null) {
 				return Response.ok(
@@ -1037,7 +1037,7 @@ public class GeoServerRestClient
 
 	/**
 	 * Add coverage to geoserver
-	 * 
+	 *
 	 * @param workspaceName
 	 * @param cvgStoreName
 	 * @param coverageName
@@ -1047,7 +1047,7 @@ public class GeoServerRestClient
 			final String workspaceName,
 			final String cvgStoreName,
 			final String coverageName ) {
-		String jsonString = "{'coverage':" + "{'name':'" + coverageName + "'," + "'nativeCoverageName':'"
+		final String jsonString = "{'coverage':" + "{'name':'" + coverageName + "'," + "'nativeCoverageName':'"
 				+ coverageName + "'}}";
 		LOGGER.debug("Posting JSON: " + jsonString + " to " + workspaceName + "/" + cvgStoreName);
 
@@ -1060,16 +1060,16 @@ public class GeoServerRestClient
 
 	/**
 	 * Delete coverage from geoserver
-	 * 
+	 *
 	 * @param workspaceName
 	 * @param cvgstoreName
 	 * @param coverageName
 	 * @return
 	 */
 	public Response deleteCoverage(
-			String workspaceName,
-			String cvgstoreName,
-			String coverageName ) {
+			final String workspaceName,
+			final String cvgstoreName,
+			final String coverageName ) {
 		return getWebTarget()
 				.path(
 						"rest/workspaces/" + workspaceName + "/coveragestores/" + cvgstoreName + "/coverages/"
@@ -1204,19 +1204,19 @@ public class GeoServerRestClient
 	}
 
 	private String createCoverageXml(
-			Map<String, String> geowaveStoreConfig,
-			Boolean equalizeHistogramOverride,
-			String interpolationOverride,
-			Boolean scaleTo8Bit ) {
+			final Map<String, String> geowaveStoreConfig,
+			final Boolean equalizeHistogramOverride,
+			final String interpolationOverride,
+			final Boolean scaleTo8Bit ) {
 		String coverageXml = null;
 
-		String workspace = geowaveStoreConfig.get(GeoServerConfig.GEOSERVER_WORKSPACE);
-		String cvgstoreName = geowaveStoreConfig.get(GeoServerConfig.GEOSERVER_CS);
+		final String workspace = geowaveStoreConfig.get(GeoServerConfig.GEOSERVER_WORKSPACE);
+		final String cvgstoreName = geowaveStoreConfig.get(GeoServerConfig.GEOSERVER_CS);
 
 		StreamResult result = null;
 		try {
 			// create the post XML
-			DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+			final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
 
 			factory.setFeature(
 					"http://xml.org/sax/features/external-general-entities",
@@ -1225,44 +1225,44 @@ public class GeoServerRestClient
 					"http://xml.org/sax/features/external-parameter-entities",
 					false);
 
-			Document xmlDoc = factory.newDocumentBuilder().newDocument();
+			final Document xmlDoc = factory.newDocumentBuilder().newDocument();
 
-			Element rootEl = xmlDoc.createElement("coverageStore");
+			final Element rootEl = xmlDoc.createElement("coverageStore");
 			xmlDoc.appendChild(rootEl);
 
-			Element nameEl = xmlDoc.createElement("name");
+			final Element nameEl = xmlDoc.createElement("name");
 			nameEl.appendChild(xmlDoc.createTextNode(cvgstoreName));
 			rootEl.appendChild(nameEl);
 
-			Element wsEl = xmlDoc.createElement("workspace");
+			final Element wsEl = xmlDoc.createElement("workspace");
 			wsEl.appendChild(xmlDoc.createTextNode(workspace));
 			rootEl.appendChild(wsEl);
 
-			Element typeEl = xmlDoc.createElement("type");
+			final Element typeEl = xmlDoc.createElement("type");
 			typeEl.appendChild(xmlDoc.createTextNode("GeoWaveRasterFormat"));
 			rootEl.appendChild(typeEl);
 
-			Element enabledEl = xmlDoc.createElement("enabled");
+			final Element enabledEl = xmlDoc.createElement("enabled");
 			enabledEl.appendChild(xmlDoc.createTextNode("true"));
 			rootEl.appendChild(enabledEl);
 
-			Element configEl = xmlDoc.createElement("configure");
+			final Element configEl = xmlDoc.createElement("configure");
 			configEl.appendChild(xmlDoc.createTextNode("all"));
 			rootEl.appendChild(configEl);
 
 			// Method using custom URL & handler:
-			String storeConfigUrl = createParamUrl(
+			final String storeConfigUrl = createParamUrl(
 					geowaveStoreConfig,
 					equalizeHistogramOverride,
 					interpolationOverride,
 					scaleTo8Bit);
 
-			Element urlEl = xmlDoc.createElement("url");
+			final Element urlEl = xmlDoc.createElement("url");
 			urlEl.appendChild(xmlDoc.createTextNode(storeConfigUrl));
 			rootEl.appendChild(urlEl);
 
 			// use a transformer to create the xml string for the rest call
-			TransformerFactory xformerFactory = TransformerFactory.newInstance();
+			final TransformerFactory xformerFactory = TransformerFactory.newInstance();
 
 			// HP Fortify "XML External Entity Injection" false positive
 			// The following modifications to xformerFactory are the
@@ -1281,9 +1281,9 @@ public class GeoServerRestClient
 					XMLConstants.ACCESS_EXTERNAL_STYLESHEET,
 					"");
 
-			Transformer xformer = xformerFactory.newTransformer();
+			final Transformer xformer = xformerFactory.newTransformer();
 
-			DOMSource source = new DOMSource(
+			final DOMSource source = new DOMSource(
 					xmlDoc);
 			result = new StreamResult(
 					new StringWriter());
@@ -1294,22 +1294,22 @@ public class GeoServerRestClient
 
 			coverageXml = result.getWriter().toString();
 		}
-		catch (TransformerException e) {
+		catch (final TransformerException e) {
 			LOGGER.error(
 					"Unable to create transformer",
 					e);
 		}
-		catch (ParserConfigurationException e1) {
+		catch (final ParserConfigurationException e1) {
 			LOGGER.error(
 					"Unable to create DocumentBuilderFactory",
 					e1);
 		}
 		finally {
-			if (result != null && result.getWriter() != null) {
+			if ((result != null) && (result.getWriter() != null)) {
 				try {
 					result.getWriter().close();
 				}
-				catch (IOException e) {
+				catch (final IOException e) {
 					LOGGER.error(e);
 				}
 			}
@@ -1319,19 +1319,19 @@ public class GeoServerRestClient
 	}
 
 	private String createParamUrl(
-			Map<String, String> geowaveStoreConfig,
-			Boolean equalizeHistogramOverride,
-			String interpolationOverride,
-			Boolean scaleTo8Bit ) {
+			final Map<String, String> geowaveStoreConfig,
+			final Boolean equalizeHistogramOverride,
+			final String interpolationOverride,
+			final Boolean scaleTo8Bit ) {
 		// Retrieve store config
-		String user = geowaveStoreConfig.get("user");
-		String pass = geowaveStoreConfig.get("password");
-		String zookeeper = geowaveStoreConfig.get("zookeeper");
-		String instance = geowaveStoreConfig.get("instance");
-		String gwNamespace = geowaveStoreConfig.get("gwNamespace");
+		final String user = geowaveStoreConfig.get("user");
+		final String pass = geowaveStoreConfig.get("password");
+		final String zookeeper = geowaveStoreConfig.get("zookeeper");
+		final String instance = geowaveStoreConfig.get("instance");
+		final String gwNamespace = geowaveStoreConfig.get("gwNamespace");
 
 		// Create the custom geowave url w/ params
-		StringBuffer buf = new StringBuffer();
+		final StringBuffer buf = new StringBuffer();
 		buf.append("user=");
 		buf.append(user);
 		buf.append(";password=");
@@ -1359,8 +1359,8 @@ public class GeoServerRestClient
 	}
 
 	public DataStorePluginOptions getStorePlugin(
-			String storeName ) {
-		StoreLoader inputStoreLoader = new StoreLoader(
+			final String storeName ) {
+		final StoreLoader inputStoreLoader = new StoreLoader(
 				storeName);
 		if (!inputStoreLoader.loadFromConfig(config.getPropFile())) {
 			throw new ParameterException(
@@ -1371,15 +1371,15 @@ public class GeoServerRestClient
 	}
 
 	public ArrayList<String> getStoreAdapters(
-			String storeName,
-			String adapterId ) {
-		ArrayList<DataAdapterInfo> adapterInfoList = getStoreAdapterInfo(
+			final String storeName,
+			final String adapterId ) {
+		final ArrayList<DataAdapterInfo> adapterInfoList = getStoreAdapterInfo(
 				storeName,
 				adapterId);
 
-		ArrayList<String> adapterIdList = new ArrayList<String>();
+		final ArrayList<String> adapterIdList = new ArrayList<String>();
 
-		for (DataAdapterInfo info : adapterInfoList) {
+		for (final DataAdapterInfo info : adapterInfoList) {
 			adapterIdList.add(info.adapterId);
 		}
 
@@ -1387,13 +1387,13 @@ public class GeoServerRestClient
 	}
 
 	private ArrayList<DataAdapterInfo> getStoreAdapterInfo(
-			String storeName,
-			String adapterId ) {
-		DataStorePluginOptions dsPlugin = getStorePlugin(storeName);
+			final String storeName,
+			final String adapterId ) {
+		final DataStorePluginOptions dsPlugin = getStorePlugin(storeName);
 
-		AdapterStore adapterStore = dsPlugin.createAdapterStore();
+		final AdapterStore adapterStore = dsPlugin.createAdapterStore();
 
-		ArrayList<DataAdapterInfo> adapterInfoList = new ArrayList<DataAdapterInfo>();
+		final ArrayList<DataAdapterInfo> adapterInfoList = new ArrayList<DataAdapterInfo>();
 
 		LOGGER.debug("Adapter list for " + storeName + " with adapterId = " + adapterId + ": ");
 
@@ -1401,7 +1401,7 @@ public class GeoServerRestClient
 			while (it.hasNext()) {
 				final DataAdapter<?> adapter = it.next();
 
-				DataAdapterInfo info = getAdapterInfo(
+				final DataAdapterInfo info = getAdapterInfo(
 						adapterId,
 						adapter);
 
@@ -1424,11 +1424,11 @@ public class GeoServerRestClient
 	}
 
 	private DataAdapterInfo getAdapterInfo(
-			String adapterId,
-			DataAdapter adapter ) {
+			final String adapterId,
+			final DataAdapter adapter ) {
 		LOGGER.debug("getAdapterInfo for id = " + adapterId);
 
-		DataAdapterInfo info = new DataAdapterInfo();
+		final DataAdapterInfo info = new DataAdapterInfo();
 		info.adapterId = adapter.getAdapterId().getString();
 		info.isRaster = false;
 
@@ -1439,7 +1439,7 @@ public class GeoServerRestClient
 		LOGGER.debug("> Adapter ID: " + info.adapterId);
 		LOGGER.debug("> Adapter Type: " + adapter.getClass().getSimpleName());
 
-		if (adapterId == null || adapterId.equals(AddOption.ALL.name())) {
+		if ((adapterId == null) || adapterId.equals(AddOption.ALL.name())) {
 			LOGGER.debug("id is null or all");
 			return info;
 		}
@@ -1449,12 +1449,12 @@ public class GeoServerRestClient
 			return info;
 		}
 
-		if (adapterId.equals(AddOption.RASTER.name()) && adapter instanceof RasterDataAdapter) {
+		if (adapterId.equals(AddOption.RASTER.name()) && (adapter instanceof RasterDataAdapter)) {
 			LOGGER.debug("id is all-raster and adapter is raster type");
 			return info;
 		}
 
-		if (adapterId.equals(AddOption.VECTOR.name()) && adapter instanceof GeotoolsFeatureDataAdapter) {
+		if (adapterId.equals(AddOption.VECTOR.name()) && (adapter instanceof GeotoolsFeatureDataAdapter)) {
 			LOGGER.debug("id is all-vector and adapter is vector type");
 			return info;
 		}

--- a/extensions/cli/osm/src/main/java/mil/nga/giat/geowave/cli/osm/mapreduce/Convert/OSMConversionMapper.java
+++ b/extensions/cli/osm/src/main/java/mil/nga/giat/geowave/cli/osm/mapreduce/Convert/OSMConversionMapper.java
@@ -2,7 +2,6 @@ package mil.nga.giat.geowave.cli.osm.mapreduce.Convert;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
 
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
@@ -14,7 +13,7 @@ import mil.nga.giat.geowave.cli.osm.mapreduce.Convert.OsmProvider.OsmProvider;
 import mil.nga.giat.geowave.cli.osm.operations.options.OSMIngestCommandArgs;
 import mil.nga.giat.geowave.core.index.ByteArrayId;
 import mil.nga.giat.geowave.core.ingest.hdfs.mapreduce.AbstractMapReduceIngest;
-import mil.nga.giat.geowave.core.store.config.ConfigUtils;
+import mil.nga.giat.geowave.core.store.operations.remote.options.DataStorePluginOptions;
 import mil.nga.giat.geowave.datastore.accumulo.operations.config.AccumuloRequiredOptions;
 import mil.nga.giat.geowave.mapreduce.output.GeoWaveOutputFormat;
 import mil.nga.giat.geowave.mapreduce.output.GeoWaveOutputKey;
@@ -82,16 +81,11 @@ public class OSMConversionMapper extends
 			args.deserializeFromString(context.getConfiguration().get(
 					"arguments"));
 
-			Map<String, String> storeOptions = GeoWaveOutputFormat.getStoreConfigOptions(context);
-
-			AccumuloRequiredOptions req = new AccumuloRequiredOptions();
-			ConfigUtils.populateOptionsFromList(
-					req,
-					storeOptions);
+			final DataStorePluginOptions storeOptions = GeoWaveOutputFormat.getStoreOptions(context);
 
 			osmProvider = new OsmProvider(
 					args,
-					req);
+					(AccumuloRequiredOptions) storeOptions.getFactoryOptions());
 		}
 		catch (final Exception e) {
 			throw new IllegalArgumentException(

--- a/extensions/cli/osm/src/main/java/mil/nga/giat/geowave/cli/osm/mapreduce/Convert/OSMConversionRunner.java
+++ b/extensions/cli/osm/src/main/java/mil/nga/giat/geowave/cli/osm/mapreduce/Convert/OSMConversionRunner.java
@@ -11,10 +11,8 @@ import org.apache.accumulo.core.client.security.tokens.PasswordToken;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.iterators.user.WholeRowIterator;
 import org.apache.accumulo.core.security.Authorizations;
-import org.apache.accumulo.core.util.Pair;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.Configured;
-import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.util.Tool;
 import org.apache.hadoop.util.ToolRunner;
@@ -29,7 +27,6 @@ import mil.nga.giat.geowave.core.geotime.ingest.SpatialDimensionalityTypeProvide
 import mil.nga.giat.geowave.core.index.StringUtils;
 import mil.nga.giat.geowave.core.ingest.hdfs.mapreduce.AbstractMapReduceIngest;
 import mil.nga.giat.geowave.core.store.adapter.AdapterStore;
-import mil.nga.giat.geowave.core.store.config.ConfigUtils;
 import mil.nga.giat.geowave.core.store.index.PrimaryIndex;
 import mil.nga.giat.geowave.core.store.operations.remote.options.DataStorePluginOptions;
 import mil.nga.giat.geowave.datastore.accumulo.AccumuloDataStoreFactory;
@@ -44,27 +41,27 @@ public class OSMConversionRunner extends
 		Tool
 {
 
-	private OSMIngestCommandArgs ingestOptions;
-	private AccumuloRequiredOptions accumuloOptions;
+	private final OSMIngestCommandArgs ingestOptions;
+	private final DataStorePluginOptions inputStoreOptions;
 
 	public static void main(
 			final String[] args )
 			throws Exception {
 
-		OSMIngestCommandArgs ingestArgs = new OSMIngestCommandArgs();
-		DataStorePluginOptions opts = new DataStorePluginOptions();
-		opts.selectPlugin(new AccumuloDataStoreFactory().getName());
+		final OSMIngestCommandArgs ingestArgs = new OSMIngestCommandArgs();
+		final DataStorePluginOptions opts = new DataStorePluginOptions();
+		opts.selectPlugin(new AccumuloDataStoreFactory().getType());
 
-		OperationParser parser = new OperationParser();
+		final OperationParser parser = new OperationParser();
 		parser.addAdditionalObject(ingestArgs);
 		parser.addAdditionalObject(opts);
 
-		CommandLineOperationParams params = parser.parse(args);
+		final CommandLineOperationParams params = parser.parse(args);
 		if (params.getSuccessCode() == 0) {
-			OSMConversionRunner runner = new OSMConversionRunner(
+			final OSMConversionRunner runner = new OSMConversionRunner(
 					ingestArgs,
 					opts);
-			int res = ToolRunner.run(
+			final int res = ToolRunner.run(
 					new Configuration(),
 					runner,
 					args);
@@ -76,16 +73,16 @@ public class OSMConversionRunner extends
 	}
 
 	public OSMConversionRunner(
-			OSMIngestCommandArgs ingestOptions,
-			DataStorePluginOptions inputStoreOptions ) {
+			final OSMIngestCommandArgs ingestOptions,
+			final DataStorePluginOptions inputStoreOptions ) {
 
 		this.ingestOptions = ingestOptions;
 		if (!inputStoreOptions.getType().equals(
-				new AccumuloDataStoreFactory().getName())) {
+				new AccumuloDataStoreFactory().getType())) {
 			throw new RuntimeException(
 					"Expected accumulo data store");
 		}
-		this.accumuloOptions = (AccumuloRequiredOptions) inputStoreOptions.getFactoryOptions();
+		this.inputStoreOptions = inputStoreOptions;
 	}
 
 	@Override
@@ -94,6 +91,7 @@ public class OSMConversionRunner extends
 			throws Exception {
 
 		final Configuration conf = getConf();
+		final AccumuloRequiredOptions accumuloOptions = (AccumuloRequiredOptions) inputStoreOptions.getFactoryOptions();
 
 		// job settings
 
@@ -150,12 +148,9 @@ public class OSMConversionRunner extends
 				Arrays.asList(r));
 
 		// output format
-		GeoWaveOutputFormat.setDataStoreName(
+		GeoWaveOutputFormat.setStoreOptions(
 				job.getConfiguration(),
-				"accumulo");
-		GeoWaveOutputFormat.setStoreConfigOptions(
-				job.getConfiguration(),
-				ConfigUtils.populateListFromOptions(accumuloOptions));
+				inputStoreOptions);
 
 		final AdapterStore as = new AccumuloAdapterStore(
 				new BasicAccumuloOperations(

--- a/extensions/cli/osm/src/main/java/mil/nga/giat/geowave/cli/osm/mapreduce/Ingest/OSMRunner.java
+++ b/extensions/cli/osm/src/main/java/mil/nga/giat/geowave/cli/osm/mapreduce/Ingest/OSMRunner.java
@@ -48,7 +48,7 @@ public class OSMRunner extends
 			throws Exception {
 		OSMIngestCommandArgs argv = new OSMIngestCommandArgs();
 		DataStorePluginOptions opts = new DataStorePluginOptions();
-		opts.selectPlugin(new AccumuloDataStoreFactory().getName());
+		opts.selectPlugin(new AccumuloDataStoreFactory().getType());
 
 		OperationParser parser = new OperationParser();
 		parser.addAdditionalObject(argv);
@@ -75,7 +75,7 @@ public class OSMRunner extends
 			DataStorePluginOptions inputStoreOptions ) {
 		this.ingestOptions = ingestOptions;
 		if (!inputStoreOptions.getType().equals(
-				new AccumuloDataStoreFactory().getName())) {
+				new AccumuloDataStoreFactory().getType())) {
 			throw new RuntimeException(
 					"Expected accumulo data store");
 		}

--- a/extensions/datastores/accumulo/src/main/java/mil/nga/giat/geowave/datastore/accumulo/AbstractAccumuloFactory.java
+++ b/extensions/datastores/accumulo/src/main/java/mil/nga/giat/geowave/datastore/accumulo/AbstractAccumuloFactory.java
@@ -7,12 +7,12 @@ import mil.nga.giat.geowave.datastore.accumulo.operations.config.AccumuloRequire
 abstract public class AbstractAccumuloFactory implements
 		GenericFactory
 {
-	private static final String NAME = AccumuloDataStore.TYPE;
+	private static final String TYPE = AccumuloDataStore.TYPE;
 	private static final String DESCRIPTION = "A GeoWave store backed by tables in Apache Accumulo";
 
 	@Override
-	public String getName() {
-		return NAME;
+	public String getType() {
+		return TYPE;
 	}
 
 	@Override
@@ -23,7 +23,7 @@ abstract public class AbstractAccumuloFactory implements
 	/**
 	 * This helps implementation of child classes by returning the default
 	 * Accumulo options that are required.
-	 * 
+	 *
 	 * @return
 	 */
 	public StoreFactoryOptions createOptionsInstance() {

--- a/extensions/datastores/accumulo/src/main/java/mil/nga/giat/geowave/datastore/accumulo/operations/config/AccumuloRequiredOptions.java
+++ b/extensions/datastores/accumulo/src/main/java/mil/nga/giat/geowave/datastore/accumulo/operations/config/AccumuloRequiredOptions.java
@@ -3,7 +3,9 @@ package mil.nga.giat.geowave.datastore.accumulo.operations.config;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParametersDelegate;
 
+import mil.nga.giat.geowave.core.store.StoreFactoryFamilySpi;
 import mil.nga.giat.geowave.core.store.StoreFactoryOptions;
+import mil.nga.giat.geowave.datastore.accumulo.AccumuloStoreFactoryFamily;
 
 /**
  * Default, required options needed in order to execute any command for
@@ -52,7 +54,7 @@ public class AccumuloRequiredOptions extends
 	}
 
 	public void setZookeeper(
-			String zookeeper ) {
+			final String zookeeper ) {
 		this.zookeeper = zookeeper;
 	}
 
@@ -61,7 +63,7 @@ public class AccumuloRequiredOptions extends
 	}
 
 	public void setInstance(
-			String instance ) {
+			final String instance ) {
 		this.instance = instance;
 	}
 
@@ -70,7 +72,7 @@ public class AccumuloRequiredOptions extends
 	}
 
 	public void setUser(
-			String user ) {
+			final String user ) {
 		this.user = user;
 	}
 
@@ -79,7 +81,7 @@ public class AccumuloRequiredOptions extends
 	}
 
 	public void setPassword(
-			String password ) {
+			final String password ) {
 		this.password = password;
 	}
 
@@ -88,7 +90,12 @@ public class AccumuloRequiredOptions extends
 	}
 
 	public void setAdditionalOptions(
-			AccumuloOptions additionalOptions ) {
+			final AccumuloOptions additionalOptions ) {
 		this.additionalOptions = additionalOptions;
+	}
+
+	@Override
+	public StoreFactoryFamilySpi getStoreFactory() {
+		return new AccumuloStoreFactoryFamily();
 	}
 }

--- a/extensions/datastores/hbase/src/main/java/mil/nga/giat/geowave/datastore/hbase/AbstractHBaseFactory.java
+++ b/extensions/datastores/hbase/src/main/java/mil/nga/giat/geowave/datastore/hbase/AbstractHBaseFactory.java
@@ -7,12 +7,12 @@ import mil.nga.giat.geowave.datastore.hbase.operations.config.HBaseRequiredOptio
 abstract public class AbstractHBaseFactory implements
 		GenericFactory
 {
-	private static final String NAME = HBaseDataStore.TYPE;
+	private static final String TYPE = HBaseDataStore.TYPE;
 	private static final String DESCRIPTION = "A GeoWave store backed by tables in Apache HBase";
 
 	@Override
-	public String getName() {
-		return NAME;
+	public String getType() {
+		return TYPE;
 	}
 
 	@Override

--- a/extensions/datastores/hbase/src/main/java/mil/nga/giat/geowave/datastore/hbase/operations/config/HBaseRequiredOptions.java
+++ b/extensions/datastores/hbase/src/main/java/mil/nga/giat/geowave/datastore/hbase/operations/config/HBaseRequiredOptions.java
@@ -3,7 +3,9 @@ package mil.nga.giat.geowave.datastore.hbase.operations.config;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParametersDelegate;
 
+import mil.nga.giat.geowave.core.store.StoreFactoryFamilySpi;
 import mil.nga.giat.geowave.core.store.StoreFactoryOptions;
+import mil.nga.giat.geowave.datastore.hbase.HBaseStoreFactoryFamily;
 
 public class HBaseRequiredOptions extends
 		StoreFactoryOptions
@@ -25,7 +27,7 @@ public class HBaseRequiredOptions extends
 	}
 
 	public void setZookeeper(
-			String zookeeper ) {
+			final String zookeeper ) {
 		this.zookeeper = zookeeper;
 	}
 
@@ -34,7 +36,12 @@ public class HBaseRequiredOptions extends
 	}
 
 	public void setAdditionalOptions(
-			HBaseOptions additionalOptions ) {
+			final HBaseOptions additionalOptions ) {
 		this.additionalOptions = additionalOptions;
+	}
+
+	@Override
+	public StoreFactoryFamilySpi getStoreFactory() {
+		return new HBaseStoreFactoryFamily();
 	}
 }

--- a/test/src/main/java/mil/nga/giat/geowave/test/StoreTestEnvironment.java
+++ b/test/src/main/java/mil/nga/giat/geowave/test/StoreTestEnvironment.java
@@ -41,7 +41,7 @@ public abstract class StoreTestEnvironment implements
 					optionOverrides);
 		}
 
-		pluginOptions.selectPlugin(factory.getName());
+		pluginOptions.selectPlugin(factory.getType());
 		pluginOptions.setFactoryOptions(opts);
 		return pluginOptions;
 	}

--- a/test/src/test/java/mil/nga/giat/geowave/test/config/ConfigCacheIT.java
+++ b/test/src/test/java/mil/nga/giat/geowave/test/config/ConfigCacheIT.java
@@ -89,7 +89,7 @@ public class ConfigCacheIT
 
 	@Test
 	public void addStore() {
-		final String storeName = new MemoryDataStoreFactory().getName();
+		final String storeName = new MemoryDataStoreFactory().getType();
 
 		final AddStoreCommand command = new AddStoreCommand();
 		command.setParameters("abc");

--- a/test/src/test/java/mil/nga/giat/geowave/test/landsat/LandsatIT.java
+++ b/test/src/test/java/mil/nga/giat/geowave/test/landsat/LandsatIT.java
@@ -188,7 +188,7 @@ public class LandsatIT
 				"=").append(
 				dataStoreOptions.getType());
 
-		final Map<String, String> options = dataStoreOptions.getFactoryOptionsAsMap();
+		final Map<String, String> options = dataStoreOptions.getOptionsAsMap();
 
 		for (final Entry<String, String> entry : options.entrySet()) {
 			if (!entry.getKey().equals(

--- a/test/src/test/java/mil/nga/giat/geowave/test/mapreduce/BasicMapReduceIT.java
+++ b/test/src/test/java/mil/nga/giat/geowave/test/mapreduce/BasicMapReduceIT.java
@@ -407,12 +407,9 @@ public class BasicMapReduceIT
 					MapReduceTestUtils.EXPECTED_RESULTS_KEY,
 					ByteArrayUtils.byteArrayToString(buf.array()));
 
-			GeoWaveInputFormat.setDataStoreName(
+			GeoWaveInputFormat.setStoreOptions(
 					conf,
-					dataStoreOptions.getType());
-			GeoWaveInputFormat.setStoreConfigOptions(
-					conf,
-					dataStoreOptions.getFactoryOptionsAsMap());
+					dataStoreOptions);
 			job.setJarByClass(this.getClass());
 
 			job.setJobName("GeoWave Test (" + dataStoreOptions.getGeowaveNamespace() + ")");

--- a/test/src/test/java/mil/nga/giat/geowave/test/mapreduce/KDERasterResizeIT.java
+++ b/test/src/test/java/mil/nga/giat/geowave/test/mapreduce/KDERasterResizeIT.java
@@ -268,7 +268,7 @@ public class KDERasterResizeIT
 				"=").append(
 				outputDataStorePluginOptions.getType());
 
-		final Map<String, String> options = outputDataStorePluginOptions.getFactoryOptionsAsMap();
+		final Map<String, String> options = outputDataStorePluginOptions.getOptionsAsMap();
 
 		for (final Entry<String, String> entry : options.entrySet()) {
 			if (!entry.getKey().equals(

--- a/test/src/test/java/mil/nga/giat/geowave/test/query/SpatialTemporalQueryIT.java
+++ b/test/src/test/java/mil/nga/giat/geowave/test/query/SpatialTemporalQueryIT.java
@@ -281,20 +281,9 @@ public class SpatialTemporalQueryIT
 			timeWriters.close();
 			rangeWriters.close();
 		}
-		final Map<String, Serializable> config = new HashMap<String, Serializable>();
-
-		final Map<String, String> mapOpts = dataStoreOptions.getFactoryOptionsAsMap();
-
-		for (final String key : mapOpts.keySet()) {
-			config.put(
-					key,
-					mapOpts.get(key));
-		}
-
 		geowaveGtDataStore = new GeoWaveGTDataStore(
 				new GeoWavePluginConfig(
-						dataStoreOptions.getFactoryFamily(),
-						config) {
+						dataStoreOptions) {
 					@Override
 					public IndexQueryStrategySPI getIndexQueryStrategy() {
 						return new IndexQueryStrategySPI() {

--- a/test/src/test/java/mil/nga/giat/geowave/test/service/GeoServerIT.java
+++ b/test/src/test/java/mil/nga/giat/geowave/test/service/GeoServerIT.java
@@ -156,7 +156,7 @@ public class GeoServerIT
 		// enable wfs & wms
 		success &= enableWfs();
 		success &= enableWms();
-		final Map<String, String> configOptions = dataStoreOptions.getFactoryOptionsAsMap();
+		final Map<String, String> configOptions = dataStoreOptions.getOptionsAsMap();
 		configOptions.put(
 				"gwNamespace",
 				TestUtils.TEST_NAMESPACE);

--- a/test/src/test/java/mil/nga/giat/geowave/test/service/GeoWaveIngestGeoserverIT.java
+++ b/test/src/test/java/mil/nga/giat/geowave/test/service/GeoWaveIngestGeoserverIT.java
@@ -139,7 +139,7 @@ public class GeoWaveIngestGeoserverIT
 				"Unable to publish '" + dataStoreOptions.getType() + "' data store",
 				geoserverServiceClient.publishDatastore(
 						dataStoreOptions.getType(),
-						dataStoreOptions.getFactoryOptionsAsMap(),
+						dataStoreOptions.getOptionsAsMap(),
 						TestUtils.TEST_NAMESPACE,
 						null,
 						null,

--- a/test/src/test/java/mil/nga/giat/geowave/test/service/GeoWaveServicesIT.java
+++ b/test/src/test/java/mil/nga/giat/geowave/test/service/GeoWaveServicesIT.java
@@ -283,7 +283,7 @@ public class GeoWaveServicesIT
 				"Unable to publish accumulo datastore",
 				geoserverServiceClient.publishDatastore(
 						dataStoreOptions.getType(),
-						dataStoreOptions.getFactoryOptionsAsMap(),
+						dataStoreOptions.getOptionsAsMap(),
 						TestUtils.TEST_NAMESPACE,
 						null,
 						null,
@@ -314,7 +314,7 @@ public class GeoWaveServicesIT
 		success = false;
 
 		if (dsInfo != null) {
-			final Map<String, String> options = dataStoreOptions.getFactoryOptionsAsMap();
+			final Map<String, String> options = dataStoreOptions.getOptionsAsMap();
 			final List<ConfigOption> configOptions = Arrays.asList(ConfigUtils
 					.createConfigOptionsFromJCommander(dataStoreOptions));
 			final Collection<String> nonPasswordRequiredFields = Collections2.transform(


### PR DESCRIPTION
hadoop input and output formats are an important external interface, and setting "datastore name" in addition to a map<String,String> is clumsy. Instead you should be able to just set the datastore plugin options.   Also, datastore "name" and "type" were being used interchangably which adds to confusion.  Settled on using "type" everywhere.