### PR TITLE
Support for DynamoDB Options

### DIFF
--- a/extensions/datastores/dynamodb/src/main/java/mil/nga/giat/geowave/datastore/dynamodb/DynamoDBClientPool.java
+++ b/extensions/datastores/dynamodb/src/main/java/mil/nga/giat/geowave/datastore/dynamodb/DynamoDBClientPool.java
@@ -5,11 +5,16 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import com.amazonaws.regions.Regions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.amazonaws.ClientConfiguration;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsyncClient;
+import com.beust.jcommander.ParameterException;
 
 public class DynamoDBClientPool
 {
+	private final Logger LOGGER = LoggerFactory.getLogger(DynamoDBClientPool.class);
 	private static DynamoDBClientPool singletonInstance;
 	private static final int DEFAULT_RETRY_THREADS = 4;
 	protected static ExecutorService DYNAMO_RETRY_POOL = Executors.newFixedThreadPool(DEFAULT_RETRY_THREADS);
@@ -27,7 +32,25 @@ public class DynamoDBClientPool
 			final DynamoDBOptions options ) {
 		AmazonDynamoDBAsyncClient client = clientCache.get(options);
 		if (client == null) {
-			client = new AmazonDynamoDBAsyncClient().withEndpoint(options.getEndpoint());
+
+			if (options.getRegion() == null && (options.getEndpoint() == null || options.getEndpoint().isEmpty())) {
+				throw new ParameterException(
+						"Compulsory to specify either the region or the endpoint");
+			}
+
+			if (options.getRegion() != null && (options.getEndpoint() != null && !options.getEndpoint().isEmpty())) {
+				LOGGER.error("Both region and endpoint specified, considering region ");
+			}
+
+			ClientConfiguration clientConfig = options.getClientConfig();
+			if (options.getRegion() == null) {
+				client = new AmazonDynamoDBAsyncClient(
+						clientConfig).withEndpoint(options.getEndpoint());
+			}
+			else {
+				client = new AmazonDynamoDBAsyncClient(
+						clientConfig).withRegion(options.getRegion());
+			}
 			clientCache.put(
 					options,
 					client);

--- a/extensions/datastores/dynamodb/src/main/java/mil/nga/giat/geowave/datastore/dynamodb/DynamoDBOptions.java
+++ b/extensions/datastores/dynamodb/src/main/java/mil/nga/giat/geowave/datastore/dynamodb/DynamoDBOptions.java
@@ -1,6 +1,11 @@
 package mil.nga.giat.geowave.datastore.dynamodb;
 
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.Protocol;
+import com.amazonaws.regions.Regions;
+import com.beust.jcommander.IStringConverter;
 import com.beust.jcommander.Parameter;
+import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.ParametersDelegate;
 
 import mil.nga.giat.geowave.core.store.BaseDataStoreOptions;
@@ -8,19 +13,95 @@ import mil.nga.giat.geowave.core.store.DataStoreOptions;
 import mil.nga.giat.geowave.core.store.StoreFactoryFamilySpi;
 import mil.nga.giat.geowave.core.store.StoreFactoryOptions;
 
+/**
+ * Jcommander helper class for AWS Region
+ *
+ */
+class RegionConvertor implements
+		IStringConverter<Regions>
+{
+
+	@Override
+	public Regions convert(
+			String regionName ) {
+		return Regions.fromName(regionName);
+	}
+
+}
+
+/**
+ * JCommander helper class for Protocol
+ *
+ */
+class ProtocolConvertor implements
+		IStringConverter<Protocol>
+{
+
+	@Override
+	public Protocol convert(
+			String protocolName ) {
+		String protocolLowerCase = protocolName.toLowerCase();
+		if (!protocolLowerCase.equals("http") && !protocolLowerCase.equals("https"))
+			throw new ParameterException(
+					"Value " + protocolName + "can not be converted to Protocol. "
+							+ "Available values are: http and https.");
+
+		return Protocol.valueOf(protocolLowerCase);
+	}
+
+}
+
 public class DynamoDBOptions extends
 		StoreFactoryOptions
 {
-	@Parameter(names = "--endpoint", required = true)
+	@Parameter(names = "--endpoint", description = "The endpoint to connect to(specify either endpoint/region not both) ", required = false)
 	protected String endpoint;
+
+	@Parameter(names = "--region", description = "The AWS region to use(specify either endpoint/region not both)")
+	protected Regions region = null;
 
 	@Parameter(names = "--initialWriteCapacity")
 	protected long writeCapacity = 5;
 	@Parameter(names = "--initialReadCapacity")
 	protected long readCapacity = 5;
 
+	/**
+	 * List of client configuration that the user can tweak
+	 */
+
+	@Parameter(names = "--maxConnections", description = "The maximum number of open http(s) connections"
+			+ " active at any given time")
+	protected int maxConnections = ClientConfiguration.DEFAULT_MAX_CONNECTIONS;
+
+	@Parameter(names = "--protocol", description = "The protocol to use. HTTP or HTTPS")
+	protected Protocol protocol = Protocol.HTTPS;
+
+	@Parameter(names = "--cacheResponseMetadata", description = "Whether to cache responses from aws(true or false). "
+			+ "High performance systems can disable this but debugging will be more difficult")
+	protected boolean enableCacheResponseMetadata = ClientConfiguration.DEFAULT_CACHE_RESPONSE_METADATA;
+
+	// End of client configuration parameters
+
 	@ParametersDelegate
 	protected BaseDataStoreOptions baseOptions = new BaseDataStoreOptions();
+
+	private ClientConfiguration clientConfig = new ClientConfiguration();
+
+	public ClientConfiguration getClientConfig() {
+		clientConfig.setCacheResponseMetadata(enableCacheResponseMetadata);
+		clientConfig.setProtocol(protocol);
+		clientConfig.setMaxConnections(maxConnections);
+		return clientConfig;
+	}
+
+	public void setRegion(
+			final Regions region ) {
+		this.region = region;
+	}
+
+	public Regions getRegion() {
+		return region;
+	}
 
 	public void setEndpoint(
 			final String endpoint ) {


### PR DESCRIPTION
Changes:
Added support for region. Now a AWS region can be specified
Made entrypoint optional.
If both are specified- region will be considered.
Added support for client configuration. Currently max number of http connections, protocol and cache response metadata is allowed.
Further support can be added easily, by modifying the "getClientConfig()" function.